### PR TITLE
Add Timer Blocks

### DIFF
--- a/src/BGDisplayFaceGraph.cpp
+++ b/src/BGDisplayFaceGraph.cpp
@@ -5,4 +5,15 @@
 
 void BGDisplayFaceGraph::showReadings(const std::list<GlucoseReading> &readings, bool dataIsOld) const {
     showGraph(0, 32, 180, readings);
+
+    auto lastReading = readings.back();
+
+    // Calculate time since last data update
+    int elapsedMinutes = (ServerManager.getUtcEpoch() - lastReading.epoch) / 60;
+
+    // Call timer block function
+    BGDisplayManager_::drawTimerBlocks(elapsedMinutes, 5, dataIsOld);
+
+    DisplayManager.update();
+    
 }

--- a/src/BGDisplayFaceGraphAndBG.cpp
+++ b/src/BGDisplayFaceGraphAndBG.cpp
@@ -15,14 +15,6 @@ void BGDisplayFaceGraphAndBG::showReadings(const std::list<GlucoseReading> &read
 
     auto lastReading = readings.back();
 
-    // Calculate time since last data update
-    int elapsedMinutes = (ServerManager.getUtcEpoch() - lastReading.epoch) / 60;
-
-    // Call timer block function
-    BGDisplayManager_::drawTimerBlocks(elapsedMinutes, 5, dataIsOld);
-
-    DisplayManager.update();
-
 #ifdef DEBUG_DISPLAY
     DEBUG_PRINTF("For the value %d, printable is: %s, text width: %u, graph width: %u\n", reading.sgv, printableReading.c_str(),
                  textWidth, grqphWidth);
@@ -31,6 +23,14 @@ void BGDisplayFaceGraphAndBG::showReadings(const std::list<GlucoseReading> &read
     showGraph(0, grqphWidth, minutesToShow, readings);
     showReading(readings.back(), 31, 6, TEXT_ALIGNMENT::RIGHT, FONT_TYPE::MEDIUM, dataIsOld);
     showTrendVerticalLine(31, readings.back().trend);
+
+     // Calculate time since last data update
+    int elapsedMinutes = (ServerManager.getUtcEpoch() - lastReading.epoch) / 60;
+
+    // Call timer block function
+    BGDisplayManager_::drawTimerBlocks(elapsedMinutes, 5, dataIsOld);
+
+    DisplayManager.update();
 }
 
 void BGDisplayFaceGraphAndBG::showTrendVerticalLine(int x, BG_TREND trend) const {

--- a/src/BGDisplayFaceGraphAndBG.cpp
+++ b/src/BGDisplayFaceGraphAndBG.cpp
@@ -13,6 +13,16 @@ void BGDisplayFaceGraphAndBG::showReadings(const std::list<GlucoseReading> &read
     uint8_t grqphWidth = 32 - textWidth - 2;
     uint8_t minutesToShow = grqphWidth * 5;
 
+    auto lastReading = readings.back();
+
+    // Calculate time since last data update
+    int elapsedMinutes = (ServerManager.getUtcEpoch() - lastReading.epoch) / 60;
+
+    // Call timer block function
+    BGDisplayManager_::drawTimerBlocks(elapsedMinutes, 5, dataIsOld);
+
+    DisplayManager.update();
+
 #ifdef DEBUG_DISPLAY
     DEBUG_PRINTF("For the value %d, printable is: %s, text width: %u, graph width: %u\n", reading.sgv, printableReading.c_str(),
                  textWidth, grqphWidth);

--- a/src/BGDisplayFaceSimple.cpp
+++ b/src/BGDisplayFaceSimple.cpp
@@ -10,4 +10,15 @@ void BGDisplayFaceSimple::showReadings(const std::list<GlucoseReading> &readings
 
     // show arrow in the right part of the screen
     showTrendArrow(readings.back(), 32 - 5, 1);
+
+    auto lastReading = readings.back();
+    
+    // Calculate time since last data update
+    int elapsedMinutes = (ServerManager.getUtcEpoch() - lastReading.epoch) / 60;
+
+    // Call timer block function
+    BGDisplayManager_::drawTimerBlocks(elapsedMinutes, 5, dataIsOld);
+
+    DisplayManager.update();
+    
 }

--- a/src/BGDisplayFaceValueAndDiff.cpp
+++ b/src/BGDisplayFaceValueAndDiff.cpp
@@ -27,6 +27,14 @@ void BGDisplayFaceValueAndDiff::showReadings(const std::list<GlucoseReading> &re
     }
 
     DisplayManager.printText(33, 6, diff.c_str(), TEXT_ALIGNMENT::RIGHT, 2);
+
+     // Calculate time since last data update
+    int elapsedMinutes = (ServerManager.getUtcEpoch() - lastReading.epoch) / 60;
+
+    // Call timer block function
+    BGDisplayManager_::drawTimerBlocks(elapsedMinutes, 5, dataIsOld);
+
+    DisplayManager.update();
 }
 
 String BGDisplayFaceValueAndDiff::getDiff(const std::list<GlucoseReading> &readings) const {

--- a/src/BGDisplayManager.cpp
+++ b/src/BGDisplayManager.cpp
@@ -110,6 +110,23 @@ void BGDisplayManager_::showData(std::list<GlucoseReading> glucoseReadings) {
     displayedReadings = glucoseReadings;
 }
 
+//Function to draw timer blocks at bottom of clock faces
+void BGDisplayManager_::drawTimerBlocks(int elapsedMinutes, int maxBlocks, bool dataIsOld) {
+    const int blockSpacing = 1; // Space between blocks
+    const int totalSpacing = blockSpacing * (maxBlocks - 1);
+    const int blockWidth = (MATRIX_WIDTH - totalSpacing) / maxBlocks; // Dynamically calculate block width
+
+    int blockCount = elapsedMinutes > maxBlocks ? maxBlocks : elapsedMinutes;
+    int startX = 1; // Start 1 pixel over to the right
+
+    for (int i = 0; i < blockCount; ++i) {
+        int blockStartX = startX + i * (blockWidth + blockSpacing); // Calculate starting position for each block
+        for (int x = blockStartX; x < blockStartX + blockWidth; ++x) {
+            DisplayManager.drawPixel(x, MATRIX_HEIGHT - 1, dataIsOld ? COLOR_RED : COLOR_GREEN);
+        }
+    }
+}
+
 GlucoseReading *BGDisplayManager_::getLastDisplayedGlucoseReading() {
     if (displayedReadings.size() > 0) {
         return &displayedReadings.back();

--- a/src/BGDisplayManager.h
+++ b/src/BGDisplayManager.h
@@ -88,6 +88,8 @@ class BGDisplayManager_ {
 
     void setFace(int id);
 
+    static void drawTimerBlocks(int elapsedMinutes, int maxBlocks, bool dataIsOld);
+
   private:
     unsigned long long lastRefreshEpoch;
 };

--- a/src/DisplayManager.h
+++ b/src/DisplayManager.h
@@ -4,6 +4,10 @@
 #include "enums.h"
 #include <Arduino.h>
 
+// Global Matrix variables 
+#define MATRIX_WIDTH 32
+#define MATRIX_HEIGHT 8
+
 class DisplayManager_ {
   private:
   public:


### PR DESCRIPTION
This will add a timer block function that will add blocks at the bottom of most clock faces based on how many minutes have passed since the last data refresh up to 5 blocks (5 minutes). Blocks turn red after the "No Data" timer expires. This works with (but not required for) https://github.com/ktomy/nightscout-clock/pull/41 that I submitted as well.

Added to clock faces:
Simple
Full Graph
Graph and BG
Value and Diff

Not on:
Big Text - It fits but doesn't look good. Maybe a different color for the timer blocks would make it look better but not sure.
Clock and value - The AM/PM bar is where the timer blocks go

Pictures of clock faces with the timer blocks:
![image](https://github.com/user-attachments/assets/58af672d-cc14-4579-b578-31bfd01d4bd0)
![image](https://github.com/user-attachments/assets/00b7c91b-e904-4fa5-bba2-3c572fc61133)
![image](https://github.com/user-attachments/assets/996cf4e8-1c8d-4b1a-8f6e-07fb155efc09)
![image](https://github.com/user-attachments/assets/8c5eb24f-636c-49c9-9405-1122aa6cac18)
![image](https://github.com/user-attachments/assets/e7fc61c3-f266-4ff8-81dd-93759e178d9f)


