### PR TITLE
feat: email validation supports gmail tag

### DIFF
--- a/data/script.js
+++ b/data/script.js
@@ -24,7 +24,7 @@
         ns_protocol: /^(http|https)$/,
         clock_timezone: /^.{2,}$/,
         time_format: /^(12|24)$/,
-        email_format: /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/,
+        email_format: /^[\w-\.]+(\+[A-Za-z0-9]+)?@([\w-]+\.)+[\w-]{2,4}$/,
         not_empty: /^.{1,}$/,
         custom_nodatatimer: /^(?:[6-9]|[1-5][0-9]|60)?$/,
 


### PR DESCRIPTION
First of all, thank you for your great job.

As a gmail user, I use a lot a gmail feature where everything past the `+` sign is ignored (johndoe@gmail.com is the same as johndoe+xyz@gmail.com), thus being able to catch services "selling" you email or register to services with multiple account (i.e. for testing purposes or to have multiple accounts of a service without having multiple emails, since gmail ignores everything past the + sign, but the service doesn't). 

Also dots are ignored, but it is not relevant here. You can find official info about gmail tags [here](https://gmail.googleblog.com/2008/03/2-hidden-ways-to-get-more-from-your.html?m=1)

I have added support for the username+tag@domain.com to the validation regex, so that whoever is using this feature can still insert their email.

Additional note: GMail supports alphanumerics only after the + sign. 
Additional note2: I don't think is worth to restrict the tag to @gmail.com domains only, since also other providers support it - let me know what you think!