### PR TITLE
Add reliability improvements: FS check, captive portal, OTA, flash fix

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -39,6 +39,14 @@ jobs:
         run: pio run --environment ulanzi
       - name: Build Release Filesystem Image
         run: pio run --target buildfs --environment ulanzi
+      - name: Verify filesystem image
+        run: |
+          FS_SIZE=$(stat -c%s .pio/build/ulanzi/littlefs.bin 2>/dev/null || stat -f%z .pio/build/ulanzi/littlefs.bin)
+          echo "littlefs.bin size: $FS_SIZE bytes"
+          if [ "$FS_SIZE" -lt 1024 ]; then
+            echo "ERROR: littlefs.bin is suspiciously small ($FS_SIZE bytes). Build may have failed."
+            exit 1
+          fi
       - name: Collect Release artifacts
         run: |
           mkdir artifacts
@@ -47,6 +55,8 @@ jobs:
           cp ~/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin artifacts/
           cp .pio/build/ulanzi/firmware.bin artifacts/
           cp .pio/build/ulanzi/littlefs.bin artifacts/
+          echo "=== Artifact sizes ==="
+          ls -la artifacts/
 
       # Build Debug
       - name: Enable all debug flags in platformio.ini

--- a/data/hotspot-detect.html
+++ b/data/hotspot-detect.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html>
+<head><meta http-equiv="refresh" content="0;url=/"></head>
+<body><a href="/">Configure Nightscout Clock</a></body>
+</html>

--- a/data/index.html
+++ b/data/index.html
@@ -7,8 +7,8 @@
     <link href="bootstrap.min.css" rel="stylesheet" />
     <link href="bootstrap-icons.min.css" rel="stylesheet" />
     <!-- <link href="all.min.css" rel="stylesheet"> -->
-    <link href="../data_dev/bootstrap.css" rel="stylesheet" />
-    <link href="../data_dev/bootstrap-icons.css" rel="stylesheet" />
+    <!-- dev-only: <link href="../data_dev/bootstrap.css" rel="stylesheet" /> -->
+    <!-- dev-only: <link href="../data_dev/bootstrap-icons.css" rel="stylesheet" /> -->
     <!-- <link href="../data_dev/all.css" rel="stylesheet"> -->
     <title>Nightscout clock</title>
 </head>
@@ -965,6 +965,29 @@
             <br class="pb-5 my-4" />
     </div>
     </form>
+
+    <!-- Firmware Update Section -->
+    <div class="container mt-4 mb-5">
+        <div class="card">
+            <div class="card-header">
+                <h5 class="mb-0">Firmware Update (OTA)</h5>
+            </div>
+            <div class="card-body">
+                <p class="text-muted">Upload a new firmware.bin file to update over-the-air.</p>
+                <div class="input-group">
+                    <input type="file" class="form-control" id="ota_file" accept=".bin">
+                    <button class="btn btn-warning" type="button" id="btn_ota_upload" onclick="uploadOTA()">
+                        Upload &amp; Update
+                    </button>
+                </div>
+                <div class="progress mt-2" style="display: none;" id="ota_progress_container">
+                    <div class="progress-bar progress-bar-striped progress-bar-animated" id="ota_progress" role="progressbar" style="width: 0%">0%</div>
+                </div>
+                <div class="mt-2" id="ota_status"></div>
+            </div>
+        </div>
+    </div>
+
     </div>
     <svg xmlns="http://www.w3.org/2000/svg" style="display: none">
         <symbol id="check-circle-fill" fill="currentColor" viewBox="0 0 16 16">
@@ -1020,12 +1043,53 @@
     </div>
 
     <script src="bootstrap.bundle.min.js"></script>
-    <script src="../data_dev/bootstrap.bundle.js"></script>
+    <!-- dev-only: <script src="../data_dev/bootstrap.bundle.js"></script> -->
     <script src="jquery.min.js"></script>
-    <script src="../data_dev/jquery.js"></script>
+    <!-- dev-only: <script src="../data_dev/jquery.js"></script> -->
     <script src="script.js"></script>
-    <!-- <script src="all.min.js"></script>
-    <script src="../data_dev/all.js"></script> -->
+    <script>
+    function uploadOTA() {
+        var fileInput = document.getElementById('ota_file');
+        if (!fileInput.files.length) {
+            document.getElementById('ota_status').innerHTML =
+                '<span class="text-danger">Please select a firmware file.</span>';
+            return;
+        }
+        var file = fileInput.files[0];
+        var formData = new FormData();
+        formData.append('update', file, file.name);
+
+        var xhr = new XMLHttpRequest();
+        var progressContainer = document.getElementById('ota_progress_container');
+        var progressBar = document.getElementById('ota_progress');
+        var statusDiv = document.getElementById('ota_status');
+
+        progressContainer.style.display = 'flex';
+        document.getElementById('btn_ota_upload').disabled = true;
+
+        xhr.upload.addEventListener('progress', function(e) {
+            if (e.lengthComputable) {
+                var pct = Math.round((e.loaded / e.total) * 100);
+                progressBar.style.width = pct + '%';
+                progressBar.textContent = pct + '%';
+            }
+        });
+        xhr.addEventListener('load', function() {
+            if (xhr.status === 200) {
+                statusDiv.innerHTML = '<span class="text-success">Update successful! Device is rebooting...</span>';
+            } else {
+                statusDiv.innerHTML = '<span class="text-danger">Update failed: ' + xhr.statusText + '</span>';
+                document.getElementById('btn_ota_upload').disabled = false;
+            }
+        });
+        xhr.addEventListener('error', function() {
+            statusDiv.innerHTML = '<span class="text-danger">Upload error. Check connection.</span>';
+            document.getElementById('btn_ota_upload').disabled = false;
+        });
+        xhr.open('POST', '/api/update');
+        xhr.send(formData);
+    }
+    </script>
 </body>
 
 </html>

--- a/data/index.html
+++ b/data/index.html
@@ -200,6 +200,9 @@
                     <div class="card">
                         <h5 class="card-header" id="headingTwo">Dexcom connection</h5>
                         <div class="card-body">
+                            <div class="alert alert-info py-2 mb-3" role="alert">
+                                <small>Use the <strong>sensor wearer's</strong> Dexcom account credentials (if you are a parent, use your child's account). Follower accounts will not work. Dexcom Share must be enabled in the Dexcom app.</small>
+                            </div>
                             <div class="row">
                                 <div class="col-lg-5 col-md-6 col-12 mb-3 mb-md-0">
                                     <label for="dexcom_username" class="form-label">Dexcom username</label>

--- a/data/index.html
+++ b/data/index.html
@@ -169,7 +169,7 @@
                             <div class="row">
                                 <div class="col-lg-6 col-md-6 col-12 mb-3 mb-md-0">
                                     <label for="medtrum_email" class="form-label">Medtrum email</label>
-                                    <input type="text" class="form-control" id="medtrum_email" />
+                                    <input type="email" class="form-control" id="medtrum_email" name="medtrum_email" autocomplete="email" />
                                     <div class="invalid-feedback">
                                         Medtrum email is required
                                     </div>
@@ -177,7 +177,7 @@
                                 <div class="col-lg-6 col-md-6 col-12 mb-3 mb-md-0">
                                     <label for="medtrum_password" class="form-label">Medtrum password</label>
                                     <div class="input-group">
-                                        <input type="password" class="form-control" id="medtrum_password" />
+                                        <input type="password" class="form-control" id="medtrum_password" name="medtrum_password" autocomplete="current-password" />
                                         <button class="btn btn-outline-secondary btn-password-toggle" type="button"
                                             data-target="#medtrum_password" aria-label="Show or hide Medtrum password">
                                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
@@ -203,7 +203,7 @@
                             <div class="row">
                                 <div class="col-lg-5 col-md-6 col-12 mb-3 mb-md-0">
                                     <label for="dexcom_username" class="form-label">Dexcom username</label>
-                                    <input type="text" class="form-control" id="dexcom_username" />
+                                    <input type="text" class="form-control" id="dexcom_username" name="dexcom_username" autocomplete="username" />
                                     <div class="invalid-feedback">
                                         Dexcom username is required
                                     </div>
@@ -211,7 +211,7 @@
                                 <div class="col-lg-5 col-md-6 col-12 mb-3 mb-md-0">
                                     <label for="dexcom_password" class="form-label">Dexcom password</label>
                                     <div class="input-group">
-                                        <input type="password" class="form-control" id="dexcom_password" />
+                                        <input type="password" class="form-control" id="dexcom_password" name="dexcom_password" autocomplete="current-password" />
                                         <button class="btn btn-outline-secondary btn-password-toggle" type="button"
                                             data-target="#dexcom_password" aria-label="Show or hide Dexcom password">
                                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
@@ -285,7 +285,7 @@
                                         <span class="text-body-secondary">(Only needed when viewing Nightscout data is
                                             protected)</span></label>
                                     <div class="input-group">
-                                        <input type="password" class="form-control" id="api_secret" />
+                                        <input type="password" class="form-control" id="api_secret" name="api_secret" autocomplete="current-password" />
                                         <button class="btn btn-outline-secondary btn-password-toggle" type="button"
                                             data-target="#api_secret" aria-label="Show or hide API secret">
                                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
@@ -324,7 +324,7 @@
                             <div class="row">
                                 <div class="col-lg-5 col-md-6 col-12 mb-3 mb-md-0">
                                     <label for="librelinkup_email" class="form-label">LibreLink Up email</label>
-                                    <input type="text" class="form-control" id="librelinkup_email" />
+                                    <input type="email" class="form-control" id="librelinkup_email" name="librelinkup_email" autocomplete="email" />
                                     <div class="invalid-feedback">
                                         LibreLink Up email is required
                                     </div>
@@ -333,7 +333,7 @@
                                     <label for="librelinkup_password" class="form-label">LibreLink Up
                                         password</label>
                                     <div class="input-group">
-                                        <input type="password" class="form-control" id="librelinkup_password" />
+                                        <input type="password" class="form-control" id="librelinkup_password" name="librelinkup_password" autocomplete="current-password" />
                                         <button class="btn btn-outline-secondary btn-password-toggle" type="button"
                                             data-target="#librelinkup_password"
                                             aria-label="Show or hide LibreLink Up password">

--- a/data/index.html
+++ b/data/index.html
@@ -201,7 +201,7 @@
                         <h5 class="card-header" id="headingTwo">Dexcom connection</h5>
                         <div class="card-body">
                             <div class="alert alert-info py-2 mb-3" role="alert">
-                                <small>Use the <strong>sensor wearer's</strong> Dexcom account credentials (if you are a parent, use your child's account). Follower accounts will not work. Dexcom Share must be enabled in the Dexcom app.</small>
+                                <small>Use the <strong>sensor wearer's</strong> Dexcom account credentials (if you are a parent, use your child's account). Follower accounts will not work. The sensor wearer must have set up Dexcom Share at least once.</small>
                             </div>
                             <div class="row">
                                 <div class="col-lg-5 col-md-6 col-12 mb-3 mb-md-0">

--- a/data/index.html
+++ b/data/index.html
@@ -1051,25 +1051,43 @@
     <!-- dev-only: <script src="../data_dev/jquery.js"></script> -->
     <script src="script.js"></script>
     <script>
+    function setOtaStatus(message, isSuccess) {
+        var statusDiv = document.getElementById('ota_status');
+        var span = document.createElement('span');
+        span.className = isSuccess ? 'text-success' : 'text-danger';
+        span.textContent = message;
+        statusDiv.innerHTML = '';
+        statusDiv.appendChild(span);
+        if (!isSuccess) {
+            document.getElementById('btn_ota_upload').disabled = false;
+        }
+    }
     function uploadOTA() {
         var fileInput = document.getElementById('ota_file');
         if (!fileInput.files.length) {
-            document.getElementById('ota_status').innerHTML =
-                '<span class="text-danger">Please select a firmware file.</span>';
+            setOtaStatus('Please select a firmware file.', false);
             return;
         }
         var file = fileInput.files[0];
+        var maxSize = 1536 * 1024;
+        if (file.size > maxSize) {
+            setOtaStatus('File too large (' + Math.round(file.size/1024) + 'KB). Max: ' + Math.round(maxSize/1024) + 'KB.', false);
+            return;
+        }
         var formData = new FormData();
         formData.append('update', file, file.name);
 
         var xhr = new XMLHttpRequest();
         var progressContainer = document.getElementById('ota_progress_container');
         var progressBar = document.getElementById('ota_progress');
-        var statusDiv = document.getElementById('ota_status');
 
+        progressBar.style.width = '0%';
+        progressBar.textContent = '0%';
         progressContainer.style.display = 'flex';
         document.getElementById('btn_ota_upload').disabled = true;
+        document.getElementById('ota_status').innerHTML = '';
 
+        xhr.timeout = 120000;
         xhr.upload.addEventListener('progress', function(e) {
             if (e.lengthComputable) {
                 var pct = Math.round((e.loaded / e.total) * 100);
@@ -1078,16 +1096,29 @@
             }
         });
         xhr.addEventListener('load', function() {
-            if (xhr.status === 200) {
-                statusDiv.innerHTML = '<span class="text-success">Update successful! Device is rebooting...</span>';
-            } else {
-                statusDiv.innerHTML = '<span class="text-danger">Update failed: ' + xhr.statusText + '</span>';
-                document.getElementById('btn_ota_upload').disabled = false;
+            try {
+                var resp = JSON.parse(xhr.responseText);
+                if (xhr.status === 200 && resp.status === 'ok') {
+                    setOtaStatus('Update successful! Device is rebooting...', true);
+                } else {
+                    setOtaStatus('Update failed: ' + (resp.message || 'Unknown error'), false);
+                }
+            } catch(e) {
+                if (xhr.status === 200) {
+                    setOtaStatus('Update successful! Device is rebooting...', true);
+                } else {
+                    setOtaStatus('Update failed (HTTP ' + xhr.status + ')', false);
+                }
             }
         });
         xhr.addEventListener('error', function() {
-            statusDiv.innerHTML = '<span class="text-danger">Upload error. Check connection.</span>';
-            document.getElementById('btn_ota_upload').disabled = false;
+            setOtaStatus('Upload error. Check connection and try again.', false);
+        });
+        xhr.addEventListener('timeout', function() {
+            setOtaStatus('Upload timed out. Check connection and try again.', false);
+        });
+        xhr.addEventListener('abort', function() {
+            setOtaStatus('Upload was cancelled.', false);
         });
         xhr.open('POST', '/api/update');
         xhr.send(formData);

--- a/partitions.csv
+++ b/partitions.csv
@@ -1,5 +1,5 @@
 nvs,      data, nvs,     36K,     20K,
 otadata,  data, ota,     56K,     8K,
-app0,     app,  ota_0,   64K,     2M,
-# app1,     app,  ota_1,   ,        1M, # disabling OTA while we are not using it for now
-spiffs,   data, spiffs,  ,        1M,
+app0,     app,  ota_0,   64K,     1536K,
+app1,     app,  ota_1,   ,        1536K,
+spiffs,   data, spiffs,  ,        512K,

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,7 +14,7 @@ default_envs = ulanzi_debug
 [env]
 platform = espressif32
 board = esp32dev
-upload_speed = 921600
+upload_speed = 460800
 framework = arduino
 board_build.f_cpu = 240000000L
 board_build.partitions = partitions.csv

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,7 +14,7 @@ default_envs = ulanzi_debug
 [env]
 platform = espressif32
 board = esp32dev
-upload_speed = 460800
+upload_speed = 921600
 framework = arduino
 board_build.f_cpu = 240000000L
 board_build.partitions = partitions.csv
@@ -35,7 +35,7 @@ lib_deps =
 	lbussy/LCBUrl@^1.1.9
 	adafruit/Adafruit SHT31 Library@^2.2.2
 
-upload_port = /dev/cu.usbserial-110
+upload_port = /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
 
 [env:ulanzi]
 build_flags = -DULANZI

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,7 +14,7 @@ default_envs = ulanzi_debug
 [env]
 platform = espressif32
 board = esp32dev
-upload_speed = 921600
+upload_speed = 460800
 framework = arduino
 board_build.f_cpu = 240000000L
 board_build.partitions = partitions.csv
@@ -35,7 +35,7 @@ lib_deps =
 	lbussy/LCBUrl@^1.1.9
 	adafruit/Adafruit SHT31 Library@^2.2.2
 
-upload_port = /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
+upload_port = /dev/cu.usbserial-110
 
 [env:ulanzi]
 build_flags = -DULANZI

--- a/src/ServerManager.cpp
+++ b/src/ServerManager.cpp
@@ -558,7 +558,8 @@ void ServerManager_::setupWebServer(IPAddress ip) {
         request->send(LittleFS, CONFIG_JSON, "application/json");
     });
 
-    // Captive portal detection endpoints for Android and Windows
+    // Captive portal detection: Android (/generate_204) and Windows (/connecttest.txt).
+    // Apple/iOS detection is handled by data/hotspot-detect.html served as a static file.
     ws->on("/generate_204", HTTP_GET, [](AsyncWebServerRequest* request) {
         request->redirect("/");
     });

--- a/src/ServerManager.cpp
+++ b/src/ServerManager.cpp
@@ -489,9 +489,12 @@ void ServerManager_::setupWebServer(IPAddress ip) {
                 return;
             }
             bool success = !Update.hasError();
-            request->send(200, "application/json",
-                          success ? "{\"status\": \"ok\", \"message\": \"Update successful, rebooting...\"}"
-                                  : "{\"status\": \"error\", \"message\": \"Update failed\"}");
+            int httpCode = success ? 200 : 500;
+            String message = success ? "Update successful, rebooting..."
+                                     : String("Update failed: ") + Update.errorString();
+            request->send(httpCode, "application/json",
+                          "{\"status\": \"" + String(success ? "ok" : "error") +
+                              "\", \"message\": \"" + message + "\"}");
             if (success) {
                 delay(1000);
                 ESP.restart();
@@ -500,17 +503,22 @@ void ServerManager_::setupWebServer(IPAddress ip) {
         [this](AsyncWebServerRequest* request, String filename, size_t index, uint8_t* data, size_t len,
                bool final) {
             if (!index) {
+                // Auth check must happen here — the completion handler runs too late
+                if (isWebAuthEnabled() && !isRequestAuthenticated(request)) {
+                    DEBUG_PRINTLN("OTA Update rejected: unauthorized");
+                    return;
+                }
                 DEBUG_PRINTF("OTA Update start: %s\n", filename.c_str());
                 if (!Update.begin(UPDATE_SIZE_UNKNOWN)) {
                     Update.printError(Serial);
                 }
             }
-            if (!Update.hasError()) {
+            if (Update.isRunning() && !Update.hasError()) {
                 if (Update.write(data, len) != len) {
                     Update.printError(Serial);
                 }
             }
-            if (final) {
+            if (final && Update.isRunning()) {
                 if (Update.end(true)) {
                     DEBUG_PRINTF("OTA Update success: %u bytes\n", index + len);
                 } else {

--- a/src/ServerManager.cpp
+++ b/src/ServerManager.cpp
@@ -5,6 +5,7 @@
 #include <ESPAsyncWebServer.h>
 #include <LittleFS.h>
 #include <WiFi.h>
+#include <Update.h>
 #include <esp_system.h>
 
 #include "BGSourceManager.h"
@@ -480,6 +481,44 @@ void ServerManager_::setupWebServer(IPAddress ip) {
         SettingsManager.factoryReset();
     });
 
+    // OTA firmware update endpoint
+    ws->on(
+        "/api/update", HTTP_POST,
+        [this](AsyncWebServerRequest* request) {
+            if (!enforceAuthentication(request)) {
+                return;
+            }
+            bool success = !Update.hasError();
+            request->send(200, "application/json",
+                          success ? "{\"status\": \"ok\", \"message\": \"Update successful, rebooting...\"}"
+                                  : "{\"status\": \"error\", \"message\": \"Update failed\"}");
+            if (success) {
+                delay(1000);
+                ESP.restart();
+            }
+        },
+        [this](AsyncWebServerRequest* request, String filename, size_t index, uint8_t* data, size_t len,
+               bool final) {
+            if (!index) {
+                DEBUG_PRINTF("OTA Update start: %s\n", filename.c_str());
+                if (!Update.begin(UPDATE_SIZE_UNKNOWN)) {
+                    Update.printError(Serial);
+                }
+            }
+            if (!Update.hasError()) {
+                if (Update.write(data, len) != len) {
+                    Update.printError(Serial);
+                }
+            }
+            if (final) {
+                if (Update.end(true)) {
+                    DEBUG_PRINTF("OTA Update success: %u bytes\n", index + len);
+                } else {
+                    Update.printError(Serial);
+                }
+            }
+        });
+
     // api call which returns status (isConnected, internet is reacheable, is in AP mode, bg source type
     // and status)
     ws->on("/api/status", HTTP_GET, [this](AsyncWebServerRequest* request) {
@@ -509,6 +548,14 @@ void ServerManager_::setupWebServer(IPAddress ip) {
             return;
         }
         request->send(LittleFS, CONFIG_JSON, "application/json");
+    });
+
+    // Captive portal detection endpoints for Android and Windows
+    ws->on("/generate_204", HTTP_GET, [](AsyncWebServerRequest* request) {
+        request->redirect("/");
+    });
+    ws->on("/connecttest.txt", HTTP_GET, [](AsyncWebServerRequest* request) {
+        request->redirect("/");
     });
 
     addStaticFileHandler();

--- a/src/ServerManager.cpp
+++ b/src/ServerManager.cpp
@@ -492,6 +492,8 @@ void ServerManager_::setupWebServer(IPAddress ip) {
             int httpCode = success ? 200 : 500;
             String message = success ? "Update successful, rebooting..."
                                      : String("Update failed: ") + Update.errorString();
+            message.replace("\\", "\\\\");
+            message.replace("\"", "\\\"");
             request->send(httpCode, "application/json",
                           "{\"status\": \"" + String(success ? "ok" : "error") +
                               "\", \"message\": \"" + message + "\"}");

--- a/src/SettingsManager.cpp
+++ b/src/SettingsManager.cpp
@@ -15,7 +15,20 @@ SettingsManager_& SettingsManager_::getInstance() {
 // Initialize the global shared instance
 SettingsManager_& SettingsManager = SettingsManager.getInstance();
 
-void SettingsManager_::setup() { LittleFS.begin(); }
+bool SettingsManager_::setup() {
+    if (!LittleFS.begin()) {
+        DEBUG_PRINTLN("LittleFS mount failed!");
+        return false;
+    }
+
+    // Verify critical filesystem files exist
+    if (!LittleFS.exists("/index.html") || !LittleFS.exists(CONFIG_JSON_FACTORY)) {
+        DEBUG_PRINTLN("Filesystem is empty or corrupt - critical files missing!");
+        return false;
+    }
+
+    return true;
+}
 
 bool copyFile(const char* srcPath, const char* destPath) {
     File srcFile = LittleFS.open(srcPath, "r");

--- a/src/SettingsManager.h
+++ b/src/SettingsManager.h
@@ -14,7 +14,7 @@ private:
 
 public:
     static SettingsManager_& getInstance();
-    void setup();
+    bool setup();
     bool loadSettingsFromFile();
     bool saveSettingsToFile();
     bool trySaveJsonAsSettings(JsonDocument doc);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,7 +53,9 @@ void setup() {
     DEBUG_PRINTLN("Setup done");
     if (ServerManager.isConnected) {
         String welcomeMessage = "Nightscout clock | To configure go to http://" + ServerManager.myIP.toString() + "/";
-        DisplayManager.scrollColorfulText(welcomeMessage);
+        for (int i = 0; i < 3; i++) {
+            DisplayManager.scrollColorfulText(welcomeMessage);
+        }
 
         DisplayManager.clearMatrix();
         DisplayManager.setTextColor(COLOR_WHITE);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,4 @@
 #include <Arduino.h>
-#include <ArduinoOTA.h>
 #include <esp32-hal.h>
 
 #include "BGAlarmManager.h"
@@ -51,13 +50,6 @@ void setup() {
     bgAlarmManager.setup();
     // PeripheryManager.playRTTTLString(sound_boot);
 
-    // Enable ArduinoOTA for PlatformIO WiFi uploads
-    if (ServerManager.isConnected) {
-        ArduinoOTA.setHostname("nsclock");
-        ArduinoOTA.begin();
-        DEBUG_PRINTLN("ArduinoOTA started");
-    }
-
     DEBUG_PRINTLN("Setup done");
     if (ServerManager.isConnected) {
         String welcomeMessage = "Nightscout clock | To configure go to http://" + ServerManager.myIP.toString() + "/";
@@ -100,7 +92,6 @@ void loop() {
     ServerManager.tick();
 
     if (ServerManager.isConnected) {
-        ArduinoOTA.handle();
         bgSourceManager.tick();
         bgDisplayManager.tick();
         bgAlarmManager.tick();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@
 #include "improv_consume.h"
 
 float apModeHintPosition = MATRIX_WIDTH;  // Start the scrolling right after the screen
+bool setupFailed = false;
 
 void setup() {
     pinMode(15, OUTPUT);
@@ -23,10 +24,13 @@ void setup() {
     DisplayManager.setup();
     if (!SettingsManager.setup()) {
         DisplayManager.showFatalError("FS empty - reflash firmware+filesystem via USB");
+        setupFailed = true;
         return;
     }
     if (!SettingsManager.loadSettingsFromFile()) {
         DisplayManager.showFatalError("Error loading software, please reinstall");
+        setupFailed = true;
+        return;
     }
 
     DisplayManager.applySettings();
@@ -53,7 +57,7 @@ void setup() {
     DEBUG_PRINTLN("Setup done");
     if (ServerManager.isConnected) {
         String welcomeMessage = "Nightscout clock | To configure go to http://" + ServerManager.myIP.toString() + "/";
-        for (int i = 0; i < 3; i++) {
+        for (int i = 0; i < 2; i++) {
             DisplayManager.scrollColorfulText(welcomeMessage);
         }
 
@@ -79,6 +83,11 @@ void showJoinAP() {
 }
 
 void loop() {
+    if (setupFailed) {
+        delay(1000);
+        return;
+    }
+
 #ifdef DEBUG_MEMORY
 
     static unsigned long lastMemoryCheck = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include <Arduino.h>
+#include <ArduinoOTA.h>
 #include <esp32-hal.h>
 
 #include "BGAlarmManager.h"
@@ -21,7 +22,10 @@ void setup() {
     // Serial.setDebugOutput(true);
 
     DisplayManager.setup();
-    SettingsManager.setup();
+    if (!SettingsManager.setup()) {
+        DisplayManager.showFatalError("FS empty - reflash firmware+filesystem via USB");
+        return;
+    }
     if (!SettingsManager.loadSettingsFromFile()) {
         DisplayManager.showFatalError("Error loading software, please reinstall");
     }
@@ -46,6 +50,13 @@ void setup() {
     bgDisplayManager.setup();
     bgAlarmManager.setup();
     // PeripheryManager.playRTTTLString(sound_boot);
+
+    // Enable ArduinoOTA for PlatformIO WiFi uploads
+    if (ServerManager.isConnected) {
+        ArduinoOTA.setHostname("nsclock");
+        ArduinoOTA.begin();
+        DEBUG_PRINTLN("ArduinoOTA started");
+    }
 
     DEBUG_PRINTLN("Setup done");
     if (ServerManager.isConnected) {
@@ -89,6 +100,7 @@ void loop() {
     ServerManager.tick();
 
     if (ServerManager.isConnected) {
+        ArduinoOTA.handle();
         bgSourceManager.tick();
         bgDisplayManager.tick();
         bgAlarmManager.tick();

--- a/www/manifest.json
+++ b/www/manifest.json
@@ -4,6 +4,7 @@
     "builds": [
         {
             "chipFamily": "ESP32",
+            "improv": true,
             "parts": [
                 {
                     "path": "https://ktomy.github.io/nightscout-clock/artifacts/bootloader.bin",
@@ -23,7 +24,7 @@
                 },
                 {
                     "path": "https://ktomy.github.io/nightscout-clock/artifacts/littlefs.bin",
-                    "offset": 2162688
+                    "offset": 3211264
                 }
             ]
         }

--- a/www/manifest.json
+++ b/www/manifest.json
@@ -5,6 +5,7 @@
         {
             "chipFamily": "ESP32",
             "improv": true,
+            "erase_before_install": true,
             "parts": [
                 {
                     "path": "https://ktomy.github.io/nightscout-clock/artifacts/bootloader.bin",


### PR DESCRIPTION
## Summary

- **Filesystem self-check on boot**: Validates that critical files (`/index.html`, `/config_initial.json`) exist after LittleFS mount. Displays clear error on LED matrix ("FS empty - reflash firmware+filesystem via USB") if filesystem is corrupt or empty, instead of silently serving 404s. Adds `setupFailed` guard in `loop()` to prevent crashes on uninitialized state.
- **Captive portal detection**: Adds iOS (`/hotspot-detect.html`), Android (`/generate_204`), and Windows (`/connecttest.txt`) captive portal routes so phones auto-popup the config page when connecting to the AP.
- **OTA firmware updates**: New dual-OTA partition layout (2×1.5MB app + 512KB filesystem) with HTTP upload endpoint at `/api/update`. Web UI includes firmware upload section with progress bar, file size validation, timeout handling, and XSS-safe status display. Respects existing web authentication (auth checked in upload handler, not just completion handler).
- **Flash reliability**: Adds `improv: true` and `erase_before_install: true` to ESP Web Tools manifest — erasing stale flash data before writing fixes the "first flash fails silently" issue. Updates LittleFS offset to match new partition layout. CI pipeline now verifies filesystem image size.
- **Dexcom credential UX**: Adds hint clarifying that sensor wearer's account is required (not follower). Adds `autocomplete` attributes for password manager support on all credential fields.
- **Cleanup**: Comments out dev-only CSS/JS references (`data_dev/`) that generated harmless but noisy log errors.

## Motivation

First-time flashing via ESP Web Tools often fails silently — the `littlefs.bin` doesn't write correctly, leaving the device with firmware but no web interface. Users have to flash twice. The `erase_before_install` flag fixes this by erasing the full flash before writing.

These changes also add OTA so future firmware updates don't require USB at all, and captive portal detection so phones auto-popup the config page.

## Partition layout change

This PR changes the partition layout from single-app to dual-OTA:

```
nvs,      data, nvs,     36K,     20K,
otadata,  data, ota,     56K,     8K,
app0,     app,  ota_0,   64K,     1536K,
app1,     app,  ota_1,   ,        1536K,
spiffs,   data, spiffs,  ,        512K,
```

Current firmware compiles to ~1.49MB (94.9% of 1.5MB partition, 79KB headroom). The filesystem (`data/`) is ~230KB, well within the 512KB partition.

**⚠️ Breaking change for existing devices:** Adopting this PR requires a full USB reflash (firmware + filesystem) since OTA cannot change the partition table. Existing settings in `config.json` will be reset to defaults — users will need to reconfigure WiFi and data source after flashing. After the initial USB flash, all future updates can use OTA.

## Known limitations

- **OTA updates firmware only, not filesystem.** If a future release changes web UI files (`index.html`, `script.js`), users would need to reflash the filesystem via USB. A filesystem OTA endpoint could be added in a future PR.
- **No automatic OTA rollback.** ESP-IDF supports rollback (revert to previous firmware if new firmware crashes on first boot), but this is not implemented. A bad OTA upload would require USB recovery. This could be added as a follow-up.
- **Upload speed change.** `platformio.ini` upload_speed changed from 921600 to 460800 for better CH340 USB-serial reliability. This only affects developers flashing via PlatformIO, not end users.

## Test plan

- [x] Flash firmware-only (no filesystem) → LED matrix shows "FS empty" error
- [x] Flash complete firmware + filesystem → device boots normally, displays Dexcom BG data
- [x] Factory reset (hold center button on boot) works
- [x] Dexcom data source connects and displays glucose readings
- [x] Password managers detect credential fields (autocomplete attributes)
- [x] OTA upload endpoint accessible at `/api/update`
- [x] OTA auth bypass fixed — unauthorized uploads rejected at first chunk
- [x] OTA error responses return HTTP 500 with JSON error details
- [x] Welcome message scrolls twice on boot (visible long enough to read IP)
- [x] Captive portal auto-popup on iOS/Android
- [ ] OTA firmware upload via web UI end-to-end
- [ ] CI pipeline filesystem size verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)