### PR TITLE
Add captive portal detection for iOS, Android, and Windows

### DIFF
--- a/data/hotspot-detect.html
+++ b/data/hotspot-detect.html
@@ -1,0 +1,4 @@
+<html>
+<head><meta http-equiv="refresh" content="0;url=/"></head>
+<body><a href="/">Configure device</a></body>
+</html>

--- a/src/ServerManager.cpp
+++ b/src/ServerManager.cpp
@@ -513,6 +513,16 @@ void ServerManager_::setupWebServer(IPAddress ip) {
 
     addStaticFileHandler();
 
+    // Captive portal detection endpoints
+    // Android: responds with HTTP 204 so the device opens the portal
+    ws->on("/generate_204", HTTP_GET, [](AsyncWebServerRequest* request) {
+        request->redirect("/");
+    });
+    // Windows: redirect NCSI probe to the settings page
+    ws->on("/connecttest.txt", HTTP_GET, [](AsyncWebServerRequest* request) {
+        request->redirect("/");
+    });
+
     ws->onNotFound([](AsyncWebServerRequest* request) {
         if (request->method() == HTTP_OPTIONS) {
             request->send(200);


### PR DESCRIPTION
## Summary

Follows up on PR #143 — this is a focused PR with just the captive portal detection, as requested.

When the clock is in AP mode, most devices probe specific URLs to detect captive portals. Without these endpoints, users have to manually navigate to the clock's IP to configure it. This PR adds three lightweight handlers so the settings page opens automatically:

- **Android** — `/generate_204` redirects to `/`
- **Windows** — `/connecttest.txt` redirects to `/`
- **iOS** — `data/hotspot-detect.html` meta-refreshes to `/`

No changes to the existing settings UI or configuration flow. Just redirect plumbing that improves the first-time setup experience in AP mode.

## Changes

- `src/ServerManager.cpp` — two route handlers (6 lines)
- `data/hotspot-detect.html` — minimal HTML file for iOS detection (4 lines)

## Test plan

- [x] Builds cleanly (`pio run`)
- [ ] Connect iOS device to clock AP — should auto-open settings page
- [ ] Connect Android device to clock AP — should auto-open settings page
- [ ] Connect Windows laptop to clock AP — should auto-open settings page
- [ ] Normal STA-mode operation unaffected