### PR TITLE
Add filesystem self-check on boot

### DIFF
--- a/src/SettingsManager.cpp
+++ b/src/SettingsManager.cpp
@@ -15,7 +15,18 @@ SettingsManager_& SettingsManager_::getInstance() {
 // Initialize the global shared instance
 SettingsManager_& SettingsManager = SettingsManager.getInstance();
 
-void SettingsManager_::setup() { LittleFS.begin(); }
+bool SettingsManager_::setup() {
+    if (!LittleFS.begin()) {
+        DEBUG_PRINTLN("LittleFS mount failed");
+        return false;
+    }
+    // Check critical files exist
+    if (!LittleFS.exists("/index.html") || !LittleFS.exists("/config_initial.json")) {
+        DEBUG_PRINTLN("Critical filesystem files missing");
+        return false;
+    }
+    return true;
+}
 
 bool copyFile(const char* srcPath, const char* destPath) {
     File srcFile = LittleFS.open(srcPath, "r");
@@ -71,7 +82,6 @@ JsonDocument* SettingsManager_::readConfigJsonFile() {
         return doc;
     } else {
         DEBUG_PRINTLN("Cannot read configuration file");
-        factoryReset();
         return NULL;
     }
 }

--- a/src/SettingsManager.h
+++ b/src/SettingsManager.h
@@ -14,7 +14,7 @@ private:
 
 public:
     static SettingsManager_& getInstance();
-    void setup();
+    bool setup();
     bool loadSettingsFromFile();
     bool saveSettingsToFile();
     bool trySaveJsonAsSettings(JsonDocument doc);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@
 #include "improv_consume.h"
 
 float apModeHintPosition = MATRIX_WIDTH;  // Start the scrolling right after the screen
+bool setupFailed = false;
 
 void setup() {
     pinMode(15, OUTPUT);
@@ -21,9 +22,15 @@ void setup() {
     // Serial.setDebugOutput(true);
 
     DisplayManager.setup();
-    SettingsManager.setup();
+    if (!SettingsManager.setup()) {
+        DisplayManager.showFatalError("FS empty - reflash firmware+filesystem via USB");
+        setupFailed = true;
+        return;
+    }
     if (!SettingsManager.loadSettingsFromFile()) {
         DisplayManager.showFatalError("Error loading software, please reinstall");
+        setupFailed = true;
+        return;
     }
 
     DisplayManager.applySettings();
@@ -74,6 +81,10 @@ void showJoinAP() {
 }
 
 void loop() {
+    if (setupFailed) {
+        delay(1000);
+        return;
+    }
 #ifdef DEBUG_MEMORY
 
     static unsigned long lastMemoryCheck = 0;


### PR DESCRIPTION
## Summary

Follow-up to #143, which was closed with feedback to split into focused PRs. This is the first of 3 focused changes ktomy identified as promising.

- `SettingsManager::setup()` now returns `bool` — validates LittleFS mount and checks that critical files (`index.html`, `config_initial.json`) exist before proceeding
- On failure, displays an actionable error message on the LED matrix: "FS empty - reflash firmware+filesystem via USB"
- `main.cpp` guards the rest of `setup()` and `loop()` with a `setupFailed` flag, preventing crashes from null pointer dereferences when the filesystem is missing
- Removes the `factoryReset()` call in `readConfigJsonFile()` when `config.json` is missing, which could cause an infinite reboot loop on a truly empty filesystem

## Motivation

First-time flashers commonly upload only the firmware binary without the LittleFS filesystem image. The current code proceeds into setup with a missing filesystem, leading to cryptic crashes or infinite reboot loops. This change catches the problem early and shows the user exactly what to do.

## Test plan

- [ ] Flash firmware **without** filesystem image — verify "FS empty" message appears on display and device does not reboot-loop
- [ ] Flash firmware **with** filesystem image — verify normal boot proceeds as before
- [ ] Delete `config.json` from filesystem — verify device does not reboot-loop (no more `factoryReset()` call on missing config)
- [ ] Verify build compiles cleanly with `pio run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)