### PR TITLE
Dexcom credential UX improvements and JSON injection fix

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -196,10 +196,13 @@
                     <div class="card">
                         <h5 class="card-header" id="headingTwo">Dexcom connection</h5>
                         <div class="card-body">
+                            <p class="form-text mt-0 mb-2">Use the same credentials you use to log into the Dexcom app on your phone.</p>
                             <div class="row">
                                 <div class="col-lg-5 col-md-6 col-12 mb-3 mb-md-0">
                                     <label for="dexcom_username" class="form-label">Dexcom username</label>
-                                    <input type="text" class="form-control" id="dexcom_username" />
+                                    <input type="text" class="form-control" id="dexcom_username"
+                                        autocomplete="username"
+                                        placeholder="Your Dexcom app login" />
                                     <div class="invalid-feedback">
                                         Dexcom username is required
                                     </div>
@@ -207,7 +210,9 @@
                                 <div class="col-lg-5 col-md-6 col-12 mb-3 mb-md-0">
                                     <label for="dexcom_password" class="form-label">Dexcom password</label>
                                     <div class="input-group">
-                                        <input type="password" class="form-control" id="dexcom_password" />
+                                        <input type="password" class="form-control" id="dexcom_password"
+                                            autocomplete="current-password"
+                                            placeholder="Your Dexcom app password" />
                                         <button class="btn btn-outline-secondary btn-password-toggle" type="button"
                                             data-target="#dexcom_password" aria-label="Show or hide Dexcom password">
                                             <i class="bi bi-eye-slash"></i>

--- a/src/ServerManager.cpp
+++ b/src/ServerManager.cpp
@@ -14,6 +14,33 @@
 #include "globals.h"
 #include "time.h"
 
+// Escape a string for safe embedding in JSON string values.
+// Prevents injection when building JSON responses by concatenation.
+static String jsonStringEscape(const String& input) {
+    String output;
+    output.reserve(input.length());
+    for (unsigned int i = 0; i < input.length(); i++) {
+        char c = input.charAt(i);
+        switch (c) {
+            case '"':  output += "\\\""; break;
+            case '\\': output += "\\\\"; break;
+            case '\n': output += "\\n"; break;
+            case '\r': output += "\\r"; break;
+            case '\t': output += "\\t"; break;
+            default:
+                if (c < 0x20) {
+                    char buf[7];
+                    snprintf(buf, sizeof(buf), "\\u%04x", (unsigned char)c);
+                    output += buf;
+                } else {
+                    output += c;
+                }
+                break;
+        }
+    }
+    return output;
+}
+
 // The getter for the instantiated singleton instance
 ServerManager_& ServerManager_::getInstance() {
     static ServerManager_ instance;
@@ -490,9 +517,9 @@ void ServerManager_::setupWebServer(IPAddress ip) {
         jsonResponse += ", \"isInAPMode\": ";
         jsonResponse += this->isInAPMode ? "true" : "false";
         jsonResponse += ", \"bgSource\": \"";
-        jsonResponse += toString(bgSourceManager.getCurrentSourceType());
+        jsonResponse += jsonStringEscape(toString(bgSourceManager.getCurrentSourceType()));
         jsonResponse += "\", \"bgSourceStatus\": \"";
-        jsonResponse += bgSourceManager.getSourceStatus();
+        jsonResponse += jsonStringEscape(bgSourceManager.getSourceStatus());
         jsonResponse += "\", \"sgv\": ";
         auto glucoseData = bgSourceManager.getGlucoseData();
         if (!glucoseData.empty()) {


### PR DESCRIPTION
Follow-up to #143 (closed per request for focused PRs). Two changes: Dexcom credential UX improvements and a small security hardening fix.

**Dexcom credential UX (data/index.html)**
- Add autocomplete=username and autocomplete=current-password so password managers can autofill
- Add placeholder text and helper text clarifying these are your Dexcom app credentials

**JSON injection hardening (src/ServerManager.cpp)**
- Add jsonStringEscape() helper for safe string embedding in concatenated JSON
- Apply to bgSource and bgSourceStatus in /api/status endpoint
- Defensive: current values are hardcoded, but prevents future injection risk

No captive portal, weather face, zip geocoding, or deferred restart included.

Builds clean: pio run -e ulanzi (71% flash, 17.6% RAM).