### PR TITLE
Fix mmol/L delta showing false ±0.1 for readings that display the same

### DIFF
--- a/src/BGDisplayFaceTextBase.cpp
+++ b/src/BGDisplayFaceTextBase.cpp
@@ -42,15 +42,36 @@ void BGDisplayFaceTextBase::SetDisplayColorByBGValue(const GlucoseReading& readi
 }
 
 String BGDisplayFaceTextBase::getPrintableReading(const int sgv) const {
-    String readingToDisplay = "";
+    return formatDisplayTenths(toDisplayTenths(sgv));
+}
+
+// `sgv` is always raw mg/dL, exactly as delivered by the data source - that never
+// changes anywhere in the codebase. This helper only produces a *local, display-scale*
+// representation of a reading, used to compare/diff readings the same way they are
+// shown on screen. It is never stored and never passed back into GlucoseReading.sgv.
+//
+// The result is scaled by 10 ("tenths") so it stays an integer that callers can use in
+// arithmetic (e.g. min/max/subtraction) before paying the string-formatting cost:
+//  - mg/dL: the displayed resolution is whole mg/dL, so this is the identity function.
+//  - mmol/L: mg/dL / 18 = mmol/L; multiplying by 10 and rounding gives the same value
+//    that gets printed with one decimal (e.g. sgv=193 -> 107, printed later as "10.7").
+int BGDisplayFaceTextBase::toDisplayTenths(const int sgv) const {
     if (SettingsManager.settings.bg_units == BG_UNIT::MGDL) {
-        readingToDisplay += String(sgv);
-    } else {
-        char buffer[10];
-        sprintf(buffer, "%.1f", round((float)sgv / 1.8) / 10);
-        readingToDisplay += String(buffer);
+        return sgv;
     }
-    return readingToDisplay;
+    return round((float)sgv / 1.8);
+}
+
+// Formats a value produced by toDisplayTenths() back into the string shown on screen
+// (e.g. 107 -> "10.7"). Kept separate from toDisplayTenths() so callers can do integer
+// arithmetic on the tenths value first and only format the final result.
+String BGDisplayFaceTextBase::formatDisplayTenths(const int tenths) const {
+    if (SettingsManager.settings.bg_units == BG_UNIT::MGDL) {
+        return String(tenths);
+    }
+    char buffer[10];
+    sprintf(buffer, "%.1f", (float)tenths / 10);
+    return String(buffer);
 }
 
 #pragma region Show arrow

--- a/src/BGDisplayFaceTextBase.h
+++ b/src/BGDisplayFaceTextBase.h
@@ -17,6 +17,8 @@ protected:
         bool isOld = false) const;
     void SetDisplayColorByBGValue(const GlucoseReading& reading) const;
     String getPrintableReading(const int sgv) const;
+    int toDisplayTenths(const int sgv) const;
+    String formatDisplayTenths(const int tenths) const;
 };
 
 #endif  // BGDISPLAYFACETEXTBASE_H

--- a/src/BGDisplayFaceValueAndDiff.cpp
+++ b/src/BGDisplayFaceValueAndDiff.cpp
@@ -63,7 +63,10 @@ String BGDisplayFaceValueAndDiff::getDiff(const std::list<GlucoseReading>& readi
         foundReadings.resize(2);
     }
 
-    // cucle through found readings, get min and max SGVs
+    // Cycle through found readings, get min and max SGVs.
+    // sgv here is always raw mg/dL - these noise/sanity checks (below) intentionally
+    // operate on the raw value regardless of the user's display unit, so switching
+    // between mg/dL and mmol/L never changes which readings are considered valid.
     int minSGV = 9999;
     int maxSGV = 0;
     for (const auto& reading : foundReadings) {
@@ -84,6 +87,7 @@ String BGDisplayFaceValueAndDiff::getDiff(const std::list<GlucoseReading>& readi
 
     int diff = minSGV == base ? base - maxSGV : base - minSGV;
 
+    // Threshold stays in raw mg/dL (99, unchanged) - no unit conversion needed here.
     if (std::abs(diff) > 99) {
 #ifdef DEBUG_DISPLAY
         DEBUG_PRINTLN("Diff is too big: " + String(diff));
@@ -91,12 +95,26 @@ String BGDisplayFaceValueAndDiff::getDiff(const std::list<GlucoseReading>& readi
         return "?";
     }
 
+    // Render the delta from the *displayed* value of each endpoint, rather than
+    // converting the raw mg/dL diff directly. Two readings that differ in mg/dL can
+    // still round to the same displayed mmol/L value (e.g. 193 and 192 mg/dL both show
+    // as "10.7"): converting the raw diff directly would then print a false -0.1/+0.1
+    // delta even though nothing changed on screen. Diffing the two rounded display
+    // values instead guarantees the delta always matches what the user can see.
+    //
+    // Trade-off: for larger gaps this can differ from "true rate of change, rounded
+    // once" by up to 0.1 mmol/L, since each endpoint is rounded independently before
+    // subtracting. That is intentional - it keeps the delta consistent with the two
+    // numbers on screen, which is what was actually reported as confusing.
+    int otherSGV = minSGV == base ? maxSGV : minSGV;
+    int diffDisplayTenths = toDisplayTenths(base) - toDisplayTenths(otherSGV);
+
     String diffString = "";
-    if (diff >= 0) {
+    if (diffDisplayTenths >= 0) {
         diffString += "+";
     }
 
-    diffString += getPrintableReading(diff);
+    diffString += formatDisplayTenths(diffDisplayTenths);
 
 #ifdef DEBUG_DISPLAY
     DEBUG_PRINTF("SGV Diff: %s (%d readings)", diffString.c_str(), foundReadings.size());


### PR DESCRIPTION
## Problem

The value/diff clock face can show a delta of `-0.1` or `+0.1` mmol/L
between two readings that display as the *exact same number*.

Example: consecutive readings of 193 and 192 mg/dL both round to
10.7 mmol/L on screen, but the delta showed `-0.1` because it was
computed from the raw 1 mg/dL difference and converted to mmol/L
afterward:

193 mg/dL -> 10.722 -> displays "10.7"
192 mg/dL -> 10.667 -> displays "10.7"
raw diff = -1 mg/dL -> -0.056 mmol/L -> rounds to "-0.1"  (shown, but wrong-looking)



## Fix

`BGDisplayFaceValueAndDiff::getDiff()` still finds the min/max/last SGV
and runs the existing noise ("too many changes in last 6.5 minutes")
and magnitude ("diff too big") guards exactly as before, entirely on
raw mg/dL values — display unit never affects which readings are
considered valid or how large a jump is allowed.

Only the final rendering step changes: instead of converting the raw
mg/dL diff directly, it now diffs the two *displayed* values (each
independently rounded to the same precision shown on screen, via
`BGDisplayFaceTextBase::toDisplayTenths`/`formatDisplayTenths`, shared
with the existing single-value display code). Two readings that show
the same number on screen now always show a `0.0` delta.

`mg/dL` mode is untouched — the conversion is the identity function
there, so behavior for mg/dL users is byte-for-byte unchanged.

## Trade-off (intentional)

Because this diffs two independently-rounded values instead of
rounding the true underlying difference once, the delta can differ
from "true rate of change, rounded once" by up to 0.1 mmol/L for
larger gaps — e.g. a 101 -> 190 mg/dL change (true delta 4.94 mmol/L)
now shows `+5.0` instead of `+4.9`. This is bounded and intentional:
the delta is defined as "what changed between the two numbers you can
see," not the precise instantaneous rate of change.

## Testing

Not tested on hardware. Verified by manual trace and by simulating the
exact logic (min/max/base/threshold/render) against several cases,
including the reported bug (193/192 mg/dL), a larger gap showing the
documented trade-off, and confirming mg/dL-mode output is unchanged
from before this PR.