### PR TITLE
Move machine-specific PlatformIO upload settings to git-ignored local override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
 .pio
+
+# Per-machine PlatformIO overrides (serial port, upload speed).
+# Copy platformio.local.ini.example to create it.
+platformio.local.ini
+
 .vscode/.browse.c_cpp.db*
 .vscode/c_cpp_properties.json
 .vscode/launch.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ For releases, follow the canonical procedure in `CONTRIBUTING.md`.
 - If needed, prepare the upcoming version changelog in `README.md`, but do not manually bump the `Current version` line before running the script.
 - After the release tag is pushed, monitor the GitHub Actions workflow `Build and deploy on Github Pages` and require it to succeed.
 
-`platformio.ini` defines the `ulanzi_debug` environment and the serial upload port used by the scripts. Check `upload_port` before flashing from a different machine or after reconnecting the device.
+`platformio.ini` defines the `ulanzi_debug` environment. Machine-specific upload settings (`upload_port`, optional faster `upload_speed`) belong in the git-ignored `platformio.local.ini` — copy `platformio.local.ini.example` to create it. The helper scripts read that file first and fall back to `platformio.ini`. Check `upload_port` there before flashing from a different machine or after reconnecting the device.
 
 ## Coding Style & Naming Conventions
 
@@ -81,6 +81,6 @@ Before opening a pull request, start a discussion or issue for non-trivial chang
 
 ## Configuration Tips
 
-`scripts/` and `platformio.ini` assume a specific serial device path for upload. If flashing fails on a different machine or after reconnecting the clock, update `upload_port` before troubleshooting deeper firmware issues.
+Per-machine upload settings live in the git-ignored `platformio.local.ini` (copy it from `platformio.local.ini.example`), not in the tracked `platformio.ini`. If flashing fails on a different machine or after reconnecting the clock, update `upload_port` there before troubleshooting deeper firmware issues.
 
 Treat `data/` as the runtime web UI payload and `data_dev/` as the local development source. If you change the device-served UI, verify both the browser behavior and the rebuilt filesystem image on hardware.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,16 @@ My computer is running linux, but you can use Windows or MacOS as well, there ar
   - install python as a PlatformIO dependency
 - clone the project using Visual Studio Code
 - PlatformIO should detect the project
-- Comment out (place `#` at the beginning of) [this](https://github.com/ktomy/nightscout-clock/blob/main/platformio.ini#L38) line
+- (Optional) Configure your machine-specific upload settings. PlatformIO
+  auto-detects the serial port, so this is only needed if auto-detect picks the
+  wrong device or you want a faster upload speed:
+  - Copy `platformio.local.ini.example` to `platformio.local.ini`
+    (`cp platformio.local.ini.example platformio.local.ini`)
+  - Set `upload_port` to your board's device path (find it with `pio device list`)
+  - `platformio.local.ini` is git-ignored, so your local settings never get
+    committed. `platformio.ini` merges it automatically via `extra_configs`.
+  - The unix helper scripts (`scripts/upload.sh`, `scripts/reset.sh`) require an
+    explicit `upload_port`, so create this file before using them.
 - You should be able to see PlatformIO tab in the sidebar
   - Select `ulanzi_debug` -> `General` -> `Build`
   - `ulanzi_debug` -> `Platform` -> `Build Filesystem image`

--- a/data/index.html
+++ b/data/index.html
@@ -725,6 +725,7 @@
                                     <option value="5">Current time and BG value</option>
                                     <option value="6">Diagnostics</option>
                                     <option value="7">Battery and uptime</option>
+                                    <option value="8">Rainbow big text</option>
                                 </select>
                                 <div class="invalid-feedback">
                                     Please select default clock face

--- a/data/index.html
+++ b/data/index.html
@@ -723,6 +723,8 @@
                                     <option value="3">Big text</option>
                                     <option value="4">Value and delta</option>
                                     <option value="5">Current time and BG value</option>
+                                    <option value="6">Diagnostics</option>
+                                    <option value="7">Battery and uptime</option>
                                 </select>
                                 <div class="invalid-feedback">
                                     Please select default clock face

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,7 +14,8 @@ default_envs = ulanzi_debug
 [env]
 platform = espressif32
 board = esp32dev
-upload_speed = 921600
+#upload_speed = 921600
+upload_speed = 460800
 framework = arduino
 board_build.f_cpu = 240000000L
 board_build.partitions = partitions.csv
@@ -35,7 +36,8 @@ lib_deps =
 	lbussy/LCBUrl@^1.1.9
 	adafruit/Adafruit SHT31 Library@^2.2.2
 
-upload_port = /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
+# upload_port = /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
+upload_port = /dev/cu.usbserial-210
 
 [env:ulanzi]
 build_flags = -DULANZI

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,11 +11,22 @@
 [platformio]
 default_envs = ulanzi_debug
 
+; Machine-specific upload settings (serial port, faster upload speed) live in an
+; untracked "platformio.local.ini" so they never get committed. Copy the tracked
+; "platformio.local.ini.example" to "platformio.local.ini" and edit it for your
+; machine. PlatformIO merges any extra_configs on top of the values below.
+; If the file does not exist, PlatformIO simply ignores it.
+extra_configs = platformio.local.ini
+
 [env]
 platform = espressif32
 board = esp32dev
-#upload_speed = 921600
-upload_speed = 460800
+; Conservative default that works on every board/cable/OS. Override with a faster
+; value (e.g. 921600) in platformio.local.ini once you know your setup is stable.
+upload_speed = 115200
+; upload_port is intentionally NOT set here. PlatformIO auto-detects the serial
+; port; pin an explicit one in platformio.local.ini only if auto-detect guesses
+; wrong (e.g. multiple boards attached). See platformio.local.ini.example.
 framework = arduino
 board_build.f_cpu = 240000000L
 board_build.partitions = partitions.csv
@@ -35,9 +46,6 @@ lib_deps =
 	lennarthennigs/Button2@^2.5.0
 	lbussy/LCBUrl@^1.1.9
 	adafruit/Adafruit SHT31 Library@^2.2.2
-
-# upload_port = /dev/serial/by-id/usb-1a86_USB_Serial-if00-port0
-upload_port = /dev/cu.usbserial-210
 
 [env:ulanzi]
 build_flags = -DULANZI

--- a/platformio.local.ini.example
+++ b/platformio.local.ini.example
@@ -1,0 +1,41 @@
+; -----------------------------------------------------------------------------
+; Per-machine PlatformIO overrides (TEMPLATE)
+; -----------------------------------------------------------------------------
+; Copy this file to "platformio.local.ini" (same directory) and edit the values
+; for YOUR computer:
+;
+;     cp platformio.local.ini.example platformio.local.ini
+;
+; "platformio.local.ini" is git-ignored, so your serial port and upload speed
+; never end up in a commit. platformio.ini references this file via:
+;
+;     [platformio]
+;     extra_configs = platformio.local.ini
+;
+; PlatformIO merges the settings below on top of platformio.ini. The helper
+; scripts (scripts/upload.sh, scripts/reset.sh) also read this file first and
+; fall back to platformio.ini.
+;
+; If you do NOT create this file, PlatformIO still auto-detects the serial port,
+; so `pio run -t upload` works out of the box. You only need it to pin a port or
+; use a faster upload speed. The raw esptool helper scripts, however, require an
+; explicit upload_port and will tell you to create this file if it is missing.
+; -----------------------------------------------------------------------------
+
+[env]
+; --- Serial port ---------------------------------------------------------------
+; Set the device path for your board. Find it with: pio device list
+;
+;   macOS    -> /dev/cu.usbserial-XXXX  or  /dev/cu.SLAB_USBtoUART
+;   Linux    -> /dev/ttyUSB0  or a stable /dev/serial/by-id/usb-...-port0 path
+;   Windows  -> COM3 (check Device Manager for the number)
+upload_port = /dev/cu.usbserial-210
+
+; --- Upload speed (optional) ---------------------------------------------------
+; platformio.ini defaults to a safe 115200. Uncomment to go faster once stable.
+; Common values: 460800, 921600. Drop back down if uploads start failing.
+;upload_speed = 921600
+
+; --- Serial monitor port (optional) --------------------------------------------
+; Usually the same as upload_port. Only needed if they differ.
+;monitor_port = /dev/cu.usbserial-210

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -25,8 +25,8 @@ fi
 if [[ $1 == "--upload" || $2 == "--upload" ]]; then
     if [[ $1 == "--fs" || $1 == "--fs" ]]; then
         echo "Uploading LittleFS..."
-        $PROJECTDIR/scripts/upload.sh --fs
+        bash "$PROJECTDIR/scripts/upload.sh" --fs
     else
-        $PROJECTDIR/scripts/upload.sh $1 $2 $3
+        bash "$PROJECTDIR/scripts/upload.sh" $1 $2 $3
     fi
 fi

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -1,8 +1,27 @@
 #!/bin/bash
 
+if [[ $PWD == *"scripts"* ]]; then
+    PROJECTDIR=$(dirname $PWD)
+else
+    PROJECTDIR=$PWD
+fi
+
+UPLOAD_PORT=$(awk -F '=' '/^upload_port/ {gsub(/ /, "", $2); print $2; exit}' "$PROJECTDIR/platformio.ini")
+UPLOAD_SPEED=$(awk -F '=' '/^upload_speed/ {gsub(/ /, "", $2); print $2; exit}' "$PROJECTDIR/platformio.ini")
+
+if [[ -z "$UPLOAD_PORT" ]]; then
+    echo "upload_port not found in platformio.ini"
+    exit 1
+fi
+
+if [[ -z "$UPLOAD_SPEED" ]]; then
+    echo "upload_speed not found in platformio.ini"
+    exit 1
+fi
+
 while true; do
     python ~/.platformio/packages/tool-esptoolpy/esptool.py \
-        --chip esp32 --port "/dev/serial/by-id/usb-1a86_USB_Serial-if00-port0" --baud 921600 --before default_reset --after hard_reset \
+        --chip esp32 --port "$UPLOAD_PORT" --baud "$UPLOAD_SPEED" --before default_reset --after hard_reset \
         run
     if [ $? -eq 0 ]; then
         break

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -6,16 +6,32 @@ else
     PROJECTDIR=$PWD
 fi
 
-UPLOAD_PORT=$(awk -F '=' '/^upload_port/ {gsub(/ /, "", $2); print $2; exit}' "$PROJECTDIR/platformio.ini")
-UPLOAD_SPEED=$(awk -F '=' '/^upload_speed/ {gsub(/ /, "", $2); print $2; exit}' "$PROJECTDIR/platformio.ini")
+# Read a PlatformIO setting, preferring the git-ignored per-machine override
+# (platformio.local.ini) and falling back to the tracked platformio.ini.
+# See platformio.local.ini.example for how to create the local file.
+CONFIG_FILES=("$PROJECTDIR/platformio.local.ini" "$PROJECTDIR/platformio.ini")
+read_ini() { # $1 = key name, e.g. upload_port
+    local key=$1 file value
+    for file in "${CONFIG_FILES[@]}"; do
+        [[ -f $file ]] || continue
+        value=$(awk -F '=' -v k="$key" '$1 ~ "^"k"[ \t]*$" {gsub(/[ \t]/, "", $2); print $2; exit}' "$file")
+        if [[ -n $value ]]; then
+            echo "$value"
+            return
+        fi
+    done
+}
+
+UPLOAD_PORT=$(read_ini upload_port)
+UPLOAD_SPEED=$(read_ini upload_speed)
 
 if [[ -z "$UPLOAD_PORT" ]]; then
-    echo "upload_port not found in platformio.ini"
+    echo "upload_port not set. Copy platformio.local.ini.example to platformio.local.ini and set upload_port (find it with: pio device list)."
     exit 1
 fi
 
 if [[ -z "$UPLOAD_SPEED" ]]; then
-    echo "upload_speed not found in platformio.ini"
+    echo "upload_speed not set in platformio.local.ini or platformio.ini"
     exit 1
 fi
 

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -6,6 +6,19 @@ else
     PROJECTDIR=$PWD
 fi
 
+UPLOAD_PORT=$(awk -F '=' '/^upload_port/ {gsub(/ /, "", $2); print $2; exit}' "$PROJECTDIR/platformio.ini")
+UPLOAD_SPEED=$(awk -F '=' '/^upload_speed/ {gsub(/ /, "", $2); print $2; exit}' "$PROJECTDIR/platformio.ini")
+
+if [[ -z "$UPLOAD_PORT" ]]; then
+    echo "upload_port not found in platformio.ini"
+    exit 1
+fi
+
+if [[ -z "$UPLOAD_SPEED" ]]; then
+    echo "upload_speed not found in platformio.ini"
+    exit 1
+fi
+
 if [[ $1 == "--fs" ]]; then
     FILES=""
 else
@@ -34,7 +47,7 @@ fi
 
 while true; do
     python ~/.platformio/packages/tool-esptoolpy/esptool.py \
-     --chip esp32 --port "/dev/serial/by-id/usb-1a86_USB_Serial-if00-port0" --baud 921600 --before default_reset --after hard_reset \
+     --chip esp32 --port "$UPLOAD_PORT" --baud "$UPLOAD_SPEED" --before default_reset --after hard_reset \
      write_flash -z --flash_mode dio --flash_freq 40m --flash_size 4MB \
      $FILES
     if [ $? -eq 0 ]; then
@@ -49,10 +62,8 @@ sleep 2
 
 if [[ $1 == "--monitor" || $2 == "--monitor" ]]; then
     echo "Starting serial monitor..."
-    $PROJECTDIR/scripts/monitor.sh
+    bash "$PROJECTDIR/scripts/monitor.sh"
 # else
 #     echo "Let's reset the device"
-#     $PROJECTDIR/scripts/reset.sh
+#     bash "$PROJECTDIR/scripts/reset.sh"
 fi
-
-

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -6,16 +6,32 @@ else
     PROJECTDIR=$PWD
 fi
 
-UPLOAD_PORT=$(awk -F '=' '/^upload_port/ {gsub(/ /, "", $2); print $2; exit}' "$PROJECTDIR/platformio.ini")
-UPLOAD_SPEED=$(awk -F '=' '/^upload_speed/ {gsub(/ /, "", $2); print $2; exit}' "$PROJECTDIR/platformio.ini")
+# Read a PlatformIO setting, preferring the git-ignored per-machine override
+# (platformio.local.ini) and falling back to the tracked platformio.ini.
+# See platformio.local.ini.example for how to create the local file.
+CONFIG_FILES=("$PROJECTDIR/platformio.local.ini" "$PROJECTDIR/platformio.ini")
+read_ini() { # $1 = key name, e.g. upload_port
+    local key=$1 file value
+    for file in "${CONFIG_FILES[@]}"; do
+        [[ -f $file ]] || continue
+        value=$(awk -F '=' -v k="$key" '$1 ~ "^"k"[ \t]*$" {gsub(/[ \t]/, "", $2); print $2; exit}' "$file")
+        if [[ -n $value ]]; then
+            echo "$value"
+            return
+        fi
+    done
+}
+
+UPLOAD_PORT=$(read_ini upload_port)
+UPLOAD_SPEED=$(read_ini upload_speed)
 
 if [[ -z "$UPLOAD_PORT" ]]; then
-    echo "upload_port not found in platformio.ini"
+    echo "upload_port not set. Copy platformio.local.ini.example to platformio.local.ini and set upload_port (find it with: pio device list)."
     exit 1
 fi
 
 if [[ -z "$UPLOAD_SPEED" ]]; then
-    echo "upload_speed not found in platformio.ini"
+    echo "upload_speed not set in platformio.local.ini or platformio.ini"
     exit 1
 fi
 

--- a/src/BGDisplayFace.cpp
+++ b/src/BGDisplayFace.cpp
@@ -5,3 +5,7 @@ void BGDisplayFace::showNoData() const {
     DisplayManager.setTextColor(COLOR_GRAY);
     DisplayManager.printText(0, 6, "No data", TEXT_ALIGNMENT::CENTER, 0);
 }
+
+bool BGDisplayFace::needsFrequentRefresh() const { return false; }
+
+unsigned long BGDisplayFace::getFrequentRefreshIntervalMs() const { return 5000; }

--- a/src/BGDisplayFace.h
+++ b/src/BGDisplayFace.h
@@ -13,6 +13,8 @@ public:
     virtual void showReadings(
         const std::list<GlucoseReading>& readings, bool dataIsOld = false) const = 0;
     virtual void showNoData() const;
+    virtual bool needsFrequentRefresh() const;
+    virtual unsigned long getFrequentRefreshIntervalMs() const;
 };
 
 #endif

--- a/src/BGDisplayFaceBatteryUptime.cpp
+++ b/src/BGDisplayFaceBatteryUptime.cpp
@@ -1,0 +1,73 @@
+#include "BGDisplayFaceBatteryUptime.h"
+
+#include "globals.h"
+
+namespace {
+constexpr int BATTERY_INDICATOR_X = 11;
+constexpr int BATTERY_INDICATOR_Y = 0;
+constexpr int BATTERY_DOT_COUNT = 10;
+
+uint16_t getBatteryColor() {
+    if (BATTERY_PERCENT < 10) {
+        return BG_COLOR_URGENT;
+    }
+    if (BATTERY_PERCENT < 30) {
+        return BG_COLOR_WARNING;
+    }
+    return BG_COLOR_NORMAL;
+}
+}  // namespace
+
+void BGDisplayFaceBatteryUptime::showReadings(
+    const std::list<GlucoseReading>& /*readings*/, bool /*dataIsOld*/) const {
+    showSystemInfo();
+}
+
+void BGDisplayFaceBatteryUptime::showNoData() const { showSystemInfo(); }
+
+bool BGDisplayFaceBatteryUptime::needsFrequentRefresh() const { return true; }
+
+unsigned long BGDisplayFaceBatteryUptime::getFrequentRefreshIntervalMs() const { return 10000; }
+
+void BGDisplayFaceBatteryUptime::showSystemInfo() const {
+    DisplayManager.clearMatrix(false);
+
+    String batteryText = String(BATTERY_PERCENT) + "%";
+    String uptimeText = formatUptime();
+
+    showBatteryIndicator();
+
+    DisplayManager.setTextColor(getBatteryColor());
+    DisplayManager.printText(0, 7, batteryText.c_str(), TEXT_ALIGNMENT::LEFT, 2, false);
+
+    DisplayManager.setTextColor(COLOR_WHITE);
+    DisplayManager.printText(31, 7, uptimeText.c_str(), TEXT_ALIGNMENT::RIGHT, 2, false);
+
+    DisplayManager.update();
+}
+
+void BGDisplayFaceBatteryUptime::showBatteryIndicator() const {
+    int filledDots = BATTERY_PERCENT == 100 ? BATTERY_DOT_COUNT : BATTERY_PERCENT / 10;
+
+    for (int i = 0; i < BATTERY_DOT_COUNT; i++) {
+        auto color = i < filledDots ? getBatteryColor() : COLOR_GRAY;
+        DisplayManager.drawPixel(BATTERY_INDICATOR_X + i, BATTERY_INDICATOR_Y, color);
+    }
+}
+
+String BGDisplayFaceBatteryUptime::formatUptime() const {
+    unsigned long uptimeSeconds = millis() / 1000;
+    unsigned long uptimeMinutes = uptimeSeconds / 60;
+
+    if (uptimeMinutes < 100) {
+        return String(uptimeMinutes) + "M";
+    }
+
+    unsigned long uptimeHours = uptimeMinutes / 60;
+    if (uptimeHours < 100) {
+        return String(uptimeHours) + "H";
+    }
+
+    unsigned long uptimeDays = uptimeHours / 24;
+    return String(uptimeDays) + "D";
+}

--- a/src/BGDisplayFaceBatteryUptime.h
+++ b/src/BGDisplayFaceBatteryUptime.h
@@ -1,0 +1,19 @@
+#ifndef BGDISPLAYFACEBATTERYUPTIME_H
+#define BGDISPLAYFACEBATTERYUPTIME_H
+
+#include "BGDisplayFace.h"
+
+class BGDisplayFaceBatteryUptime : public BGDisplayFace {
+public:
+    void showReadings(const std::list<GlucoseReading>& readings, bool dataIsOld = false) const override;
+    void showNoData() const override;
+    bool needsFrequentRefresh() const override;
+    unsigned long getFrequentRefreshIntervalMs() const override;
+
+private:
+    void showSystemInfo() const;
+    void showBatteryIndicator() const;
+    String formatUptime() const;
+};
+
+#endif

--- a/src/BGDisplayFaceBigTextRainbow.cpp
+++ b/src/BGDisplayFaceBigTextRainbow.cpp
@@ -1,0 +1,85 @@
+#include "BGDisplayFaceBigTextRainbow.h"
+
+#include "globals.h"
+
+namespace {
+constexpr unsigned long RAINBOW_REFRESH_INTERVAL_MS = 80;
+constexpr uint8_t RAINBOW_BLEND_AMOUNT = 88;
+
+uint16_t rgb565(uint8_t red, uint8_t green, uint8_t blue) {
+    return ((uint16_t)(red & 0xF8) << 8) | ((uint16_t)(green & 0xFC) << 3) | (blue >> 3);
+}
+
+uint16_t hsvToRgb565(uint8_t hue) {
+    uint8_t region = hue / 43;
+    uint8_t remainder = (hue - (region * 43)) * 6;
+    uint8_t q = 255 - remainder;
+    uint8_t t = remainder;
+
+    switch (region) {
+        case 0:
+            return rgb565(255, t, 0);
+        case 1:
+            return rgb565(q, 255, 0);
+        case 2:
+            return rgb565(0, 255, t);
+        case 3:
+            return rgb565(0, q, 255);
+        case 4:
+            return rgb565(t, 0, 255);
+        default:
+            return rgb565(255, 0, q);
+    }
+}
+
+uint8_t redFromRgb565(uint16_t color) { return ((color >> 11) & 0x1F) * 255 / 31; }
+uint8_t greenFromRgb565(uint16_t color) { return ((color >> 5) & 0x3F) * 255 / 63; }
+uint8_t blueFromRgb565(uint16_t color) { return (color & 0x1F) * 255 / 31; }
+
+uint16_t blendRgb565(uint16_t baseColor, uint16_t overlayColor, uint8_t overlayAmount) {
+    uint16_t baseAmount = 255 - overlayAmount;
+    uint8_t red = (redFromRgb565(baseColor) * baseAmount + redFromRgb565(overlayColor) * overlayAmount) / 255;
+    uint8_t green =
+        (greenFromRgb565(baseColor) * baseAmount + greenFromRgb565(overlayColor) * overlayAmount) / 255;
+    uint8_t blue =
+        (blueFromRgb565(baseColor) * baseAmount + blueFromRgb565(overlayColor) * overlayAmount) / 255;
+
+    return rgb565(red, green, blue);
+}
+}  // namespace
+
+void BGDisplayFaceBigTextRainbow::showReadings(
+    const std::list<GlucoseReading>& readings, bool dataIsOld) const {
+    auto lastReading = readings.back();
+    showAnimatedReading(lastReading, dataIsOld);
+
+    showTrendArrow(lastReading, MATRIX_WIDTH - 5, 1, dataIsOld, true, false);
+    DisplayManager.update();
+}
+
+bool BGDisplayFaceBigTextRainbow::needsFrequentRefresh() const { return true; }
+
+unsigned long BGDisplayFaceBigTextRainbow::getFrequentRefreshIntervalMs() const {
+    return RAINBOW_REFRESH_INTERVAL_MS;
+}
+
+void BGDisplayFaceBigTextRainbow::showAnimatedReading(
+    const GlucoseReading& reading, bool dataIsOld) const {
+    String readingToDisplay = getPrintableReading(reading.sgv);
+    uint16_t baseColor = dataIsOld ? BG_COLOR_OLD : getDisplayColorByBGValue(reading);
+    uint8_t hueOffset = (millis() / 20) % 255;
+    uint8_t textLength = readingToDisplay.length();
+    int16_t x = 0;
+
+    DisplayManager.setFont(FONT_TYPE::LARGE);
+
+    for (uint8_t i = 0; i < textLength; i++) {
+        char text[2] = {readingToDisplay[i], '\0'};
+        uint8_t hue = map(i, 0, max((int)textLength, 1), 0, 255) + hueOffset;
+        uint16_t color = dataIsOld ? baseColor : blendRgb565(baseColor, hsvToRgb565(hue), RAINBOW_BLEND_AMOUNT);
+
+        DisplayManager.setTextColor(color);
+        DisplayManager.printText(x, 7, text, TEXT_ALIGNMENT::LEFT, 2, false);
+        x += DisplayManager.getTextWidth(text, 2);
+    }
+}

--- a/src/BGDisplayFaceBigTextRainbow.h
+++ b/src/BGDisplayFaceBigTextRainbow.h
@@ -1,0 +1,17 @@
+#ifndef BGDISPLAYFACEBIGTEXTRAINBOW_H
+#define BGDISPLAYFACEBIGTEXTRAINBOW_H
+
+#include "BGDisplayFaceTextBase.h"
+#include "BGSource.h"
+
+class BGDisplayFaceBigTextRainbow : public BGDisplayFaceTextBase {
+public:
+    void showReadings(const std::list<GlucoseReading>& readings, bool dataIsOld = false) const override;
+    bool needsFrequentRefresh() const override;
+    unsigned long getFrequentRefreshIntervalMs() const override;
+
+private:
+    void showAnimatedReading(const GlucoseReading& reading, bool dataIsOld) const;
+};
+
+#endif

--- a/src/BGDisplayFaceDiagnostics.cpp
+++ b/src/BGDisplayFaceDiagnostics.cpp
@@ -1,0 +1,98 @@
+#include "BGDisplayFaceDiagnostics.h"
+
+#include "ServerManager.h"
+#include "globals.h"
+
+namespace {
+constexpr int CONTENT_BASELINE_Y = 7;
+constexpr int STATUS_ITEM_SPACING = 2;
+constexpr int ARROW_SPACING = 1;
+constexpr int ARROW_WIDTH = 5;
+constexpr int DATETIME_SCROLL_LEFT_PADDING = 2;
+constexpr unsigned long DATETIME_SCROLL_FRAME_MS = 16;
+constexpr float DATETIME_SCROLL_STEP_PIXELS = 0.18f;
+const char* WEEKDAY_NAMES[] = {"SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"};
+}  // namespace
+
+void BGDisplayFaceDiagnostics::showReadings(
+    const std::list<GlucoseReading>& readings, bool dataIsOld) const {
+    showDateTimePage(readings, dataIsOld);
+}
+
+void BGDisplayFaceDiagnostics::showNoData() const {
+    String dateTimeText = formatDateTime();
+    String noDataText = SettingsManager.settings.bg_units == BG_UNIT::MMOLL ? "--.-" : "---";
+    int dateTimeWidth = (int)DisplayManager.getTextWidth(dateTimeText.c_str(), 2);
+    int noDataWidth = (int)DisplayManager.getTextWidth(noDataText.c_str(), 2);
+    int contentWidth = dateTimeWidth + STATUS_ITEM_SPACING + noDataWidth;
+    int scrollX = getScrollX(contentWidth);
+
+    DisplayManager.clearMatrix(false);
+
+    DisplayManager.setTextColor(COLOR_CYAN);
+    DisplayManager.printText(scrollX, CONTENT_BASELINE_Y, dateTimeText.c_str(), TEXT_ALIGNMENT::LEFT, 2, false);
+
+    DisplayManager.setTextColor(BG_COLOR_OLD);
+    DisplayManager.printText(
+        scrollX + dateTimeWidth + STATUS_ITEM_SPACING, CONTENT_BASELINE_Y, noDataText.c_str(),
+        TEXT_ALIGNMENT::LEFT, 2, false);
+
+    DisplayManager.update();
+}
+
+bool BGDisplayFaceDiagnostics::needsFrequentRefresh() const { return true; }
+
+unsigned long BGDisplayFaceDiagnostics::getFrequentRefreshIntervalMs() const {
+    return DATETIME_SCROLL_FRAME_MS;
+}
+
+void BGDisplayFaceDiagnostics::showDateTimePage(
+    const std::list<GlucoseReading>& readings, bool dataIsOld) const {
+    auto lastReading = readings.back();
+    String dateTimeText = formatDateTime();
+    String printableReading = getPrintableReading(lastReading.sgv);
+    int dateTimeWidth = (int)DisplayManager.getTextWidth(dateTimeText.c_str(), 2);
+    int readingWidth = (int)DisplayManager.getTextWidth(printableReading.c_str(), 2);
+    int readingX = dateTimeWidth + STATUS_ITEM_SPACING;
+    int arrowX = readingX + readingWidth + ARROW_SPACING;
+    int contentWidth = arrowX + ARROW_WIDTH;
+    int scrollX = getScrollX(contentWidth);
+
+    DisplayManager.clearMatrix(false);
+
+    DisplayManager.setTextColor(COLOR_CYAN);
+    DisplayManager.printText(scrollX, CONTENT_BASELINE_Y, dateTimeText.c_str(), TEXT_ALIGNMENT::LEFT, 2, false);
+
+    showReading(
+        lastReading, scrollX + readingX, CONTENT_BASELINE_Y, TEXT_ALIGNMENT::LEFT, FONT_TYPE::MEDIUM,
+        dataIsOld, false);
+    showTrendArrow(lastReading, scrollX + arrowX, 2, dataIsOld, true, false);
+
+    DisplayManager.update();
+}
+
+int BGDisplayFaceDiagnostics::getScrollX(int contentWidth) const {
+    if (contentWidth <= MATRIX_WIDTH) {
+        return max(0, (MATRIX_WIDTH - contentWidth) / 2);
+    }
+
+    float travel = contentWidth + MATRIX_WIDTH + DATETIME_SCROLL_LEFT_PADDING;
+    float position = MATRIX_WIDTH - fmodf(
+                                        (millis() / (float)DATETIME_SCROLL_FRAME_MS) *
+                                            DATETIME_SCROLL_STEP_PIXELS,
+                                        travel);
+
+    return (int)position;
+}
+
+String BGDisplayFaceDiagnostics::formatDateTime() const {
+    tm timeinfo = ServerManager.getTimezonedTime();
+    char dateTimeBuffer[20];
+
+    snprintf(
+        dateTimeBuffer, sizeof(dateTimeBuffer), "%s %02d/%02d %02d:%02d",
+        WEEKDAY_NAMES[timeinfo.tm_wday], timeinfo.tm_mday, timeinfo.tm_mon + 1, timeinfo.tm_hour,
+        timeinfo.tm_min);
+
+    return String(dateTimeBuffer);
+}

--- a/src/BGDisplayFaceDiagnostics.h
+++ b/src/BGDisplayFaceDiagnostics.h
@@ -1,0 +1,19 @@
+#ifndef BGDISPLAYFACEDIAGNOSTICS_H
+#define BGDISPLAYFACEDIAGNOSTICS_H
+
+#include "BGDisplayFaceTextBase.h"
+
+class BGDisplayFaceDiagnostics : public BGDisplayFaceTextBase {
+public:
+    void showReadings(const std::list<GlucoseReading>& readings, bool dataIsOld = false) const override;
+    void showNoData() const override;
+    bool needsFrequentRefresh() const override;
+    unsigned long getFrequentRefreshIntervalMs() const override;
+
+private:
+    void showDateTimePage(const std::list<GlucoseReading>& readings, bool dataIsOld) const;
+    int getScrollX(int contentWidth) const;
+    String formatDateTime() const;
+};
+
+#endif

--- a/src/BGDisplayFaceTextBase.cpp
+++ b/src/BGDisplayFaceTextBase.cpp
@@ -7,7 +7,7 @@
 
 void BGDisplayFaceTextBase::showReading(
     const GlucoseReading reading, int16_t x, int16_t y, TEXT_ALIGNMENT alignment, FONT_TYPE font,
-    bool isOld) const {
+    bool isOld, bool updateMatrix) const {
     String readingToDisplay = getPrintableReading(reading.sgv);
     if (!isOld) {
         SetDisplayColorByBGValue(reading);
@@ -17,10 +17,14 @@ void BGDisplayFaceTextBase::showReading(
 
     DisplayManager.setFont(font);
 
-    DisplayManager.printText(x, y, readingToDisplay.c_str(), alignment, 2);
+    DisplayManager.printText(x, y, readingToDisplay.c_str(), alignment, 2, updateMatrix);
 }
 
 void BGDisplayFaceTextBase::SetDisplayColorByBGValue(const GlucoseReading& reading) const {
+    DisplayManager.setTextColor(getDisplayColorByBGValue(reading));
+}
+
+uint16_t BGDisplayFaceTextBase::getDisplayColorByBGValue(const GlucoseReading& reading) const {
     auto bgLevel = bgDisplayManager.getGlucoseIntervals().getBGLevel(reading.sgv);
     auto textColor = COLOR_GRAY;
 
@@ -38,7 +42,7 @@ void BGDisplayFaceTextBase::SetDisplayColorByBGValue(const GlucoseReading& readi
             break;
     }
 
-    DisplayManager.setTextColor(textColor);
+    return textColor;
 }
 
 String BGDisplayFaceTextBase::getPrintableReading(const int sgv) const {
@@ -96,13 +100,16 @@ const std::map<BG_TREND, const uint8_t*> glucoseTrendSymbols = {
 };
 
 void BGDisplayFaceTextBase::showTrendArrow(
-    const GlucoseReading reading, int16_t x, int16_t y, bool dataIsOld) const {
+    const GlucoseReading reading, int16_t x, int16_t y, bool dataIsOld, bool colorByReading,
+    bool updateMatrix) const {
     uint16_t color = COLOR_WHITE;
     if (dataIsOld) {
         color = BG_COLOR_OLD;
+    } else if (colorByReading) {
+        color = getDisplayColorByBGValue(reading);
     }
 
-    DisplayManager.drawBitmap(x, y, glucoseTrendSymbols.at(reading.trend), 5, 5, color);
+    DisplayManager.drawBitmap(x, y, glucoseTrendSymbols.at(reading.trend), 5, 5, color, updateMatrix);
 }
 
 #pragma endregion Show arrow

--- a/src/BGDisplayFaceTextBase.h
+++ b/src/BGDisplayFaceTextBase.h
@@ -10,12 +10,15 @@ public:
         const std::list<GlucoseReading>& readings, bool dataIsOld = false) const = 0;
 
 protected:
-    void showTrendArrow(const GlucoseReading reading, int16_t x, int16_t y, bool dataIsOld) const;
+    void showTrendArrow(
+        const GlucoseReading reading, int16_t x, int16_t y, bool dataIsOld,
+        bool colorByReading = false, bool updateMatrix = true) const;
     void showTrendVerticalLine(int x, BG_TREND trend, bool dataIsOld) const;
     void showReading(
         const GlucoseReading reading, int16_t x, int16_t y, TEXT_ALIGNMENT alignment, FONT_TYPE fontType,
-        bool isOld = false) const;
+        bool isOld = false, bool updateMatrix = true) const;
     void SetDisplayColorByBGValue(const GlucoseReading& reading) const;
+    uint16_t getDisplayColorByBGValue(const GlucoseReading& reading) const;
     String getPrintableReading(const int sgv) const;
 };
 

--- a/src/BGDisplayManager.cpp
+++ b/src/BGDisplayManager.cpp
@@ -47,6 +47,10 @@ void BGDisplayManager_::setup() {
     facesNames[4] = "Value and diff";
     faces.push_back(new BGDisplayFaceClock());
     facesNames[5] = "Clock and value";
+    faces.push_back(new BGDisplayFaceDiagnostics());
+    facesNames[6] = "Diagnostics";
+    faces.push_back(new BGDisplayFaceBatteryUptime());
+    facesNames[7] = "Battery and uptime";
 
     currentFaceIndex = SettingsManager.settings.default_clockface;
     if (currentFaceIndex >= faces.size()) {
@@ -76,19 +80,24 @@ void BGDisplayManager_::tick() { maybeRrefreshScreen(); }
 
 void BGDisplayManager_::maybeRrefreshScreen(bool force) {
     auto currentEpoch = ServerManager.getUtcEpoch();
+    auto currentMillis = millis();
     tm timeInfo = ServerManager.getTimezonedTime();
+    bool frequentRefresh = currentFace->needsFrequentRefresh();
+    unsigned long refreshIntervalMs = frequentRefresh ? currentFace->getFrequentRefreshIntervalMs() : 60000;
+    unsigned long long refreshClock = frequentRefresh ? currentMillis : currentEpoch;
 
     auto lastReading = bgDisplayManager.getLastDisplayedGlucoseReading();
 
     if (bgSourceManager.hasNewData(lastReading == NULL ? 0 : lastReading->epoch)) {
         DEBUG_PRINTLN("We have new data");
         bgDisplayManager.showData(bgSourceManager.getInstance().getGlucoseData());
-        lastRefreshEpoch = currentEpoch;
+        lastRefreshEpoch = refreshClock;
     } else {
         // We refresh the display every minue trying to match the exact :00 second
-        if (force || timeInfo.tm_sec == 0 && currentEpoch > lastRefreshEpoch ||
-            currentEpoch - lastRefreshEpoch > 60) {
-            lastRefreshEpoch = currentEpoch;
+        if (force || frequentRefresh && refreshClock - lastRefreshEpoch >= refreshIntervalMs ||
+            timeInfo.tm_sec == 0 && currentEpoch > lastRefreshEpoch ||
+            !frequentRefresh && currentEpoch - lastRefreshEpoch > 60) {
+            lastRefreshEpoch = refreshClock;
             if (displayedReadings.size() > 0) {
                 bool dataIsOld = displayedReadings.back().getSecondsAgo() >
                                  60 * SettingsManager.settings.bg_data_too_old_threshold_minutes;

--- a/src/BGDisplayManager.cpp
+++ b/src/BGDisplayManager.cpp
@@ -51,6 +51,8 @@ void BGDisplayManager_::setup() {
     facesNames[6] = "Diagnostics";
     faces.push_back(new BGDisplayFaceBatteryUptime());
     facesNames[7] = "Battery and uptime";
+    faces.push_back(new BGDisplayFaceBigTextRainbow());
+    facesNames[8] = "Rainbow big text";
 
     currentFaceIndex = SettingsManager.settings.default_clockface;
     if (currentFaceIndex >= faces.size()) {

--- a/src/BGDisplayManager.h
+++ b/src/BGDisplayManager.h
@@ -8,8 +8,10 @@
 #include <vector>
 
 #include "BGDisplayFace.h"
+#include "BGDisplayFaceBatteryUptime.h"
 #include "BGDisplayFaceBigText.h"
 #include "BGDisplayFaceClock.h"
+#include "BGDisplayFaceDiagnostics.h"
 #include "BGDisplayFaceGraph.h"
 #include "BGDisplayFaceGraphAndBG.h"
 #include "BGDisplayFaceSimple.h"

--- a/src/BGDisplayManager.h
+++ b/src/BGDisplayManager.h
@@ -10,6 +10,7 @@
 #include "BGDisplayFace.h"
 #include "BGDisplayFaceBatteryUptime.h"
 #include "BGDisplayFaceBigText.h"
+#include "BGDisplayFaceBigTextRainbow.h"
 #include "BGDisplayFaceClock.h"
 #include "BGDisplayFaceDiagnostics.h"
 #include "BGDisplayFaceGraph.h"

--- a/src/DisplayManager.cpp
+++ b/src/DisplayManager.cpp
@@ -134,9 +134,11 @@ float DisplayManager_::getTextWidth(const char* text, byte textCase) {
 }
 void DisplayManager_::setTextColor(uint16_t color) { matrix->setTextColor(color); }
 
-void DisplayManager_::clearMatrix() {
+void DisplayManager_::clearMatrix(bool updateMatrix) {
     matrix->clear();
-    matrix->show();
+    if (updateMatrix) {
+        matrix->show();
+    }
 }
 
 // DisplayManager_::printText(int16_t x, int16_t y, const char *text, TEXT_ALIGNMENT alignment, byte
@@ -144,7 +146,7 @@ void DisplayManager_::clearMatrix() {
 // }
 
 void DisplayManager_::printText(
-    int16_t x, int16_t y, const char* text, TEXT_ALIGNMENT alignment, byte textCase) {
+    int16_t x, int16_t y, const char* text, TEXT_ALIGNMENT alignment, byte textCase, bool updateMatrix) {
     if (alignment == TEXT_ALIGNMENT::LEFT) {
         matrix->setCursor(x, y);
     } else if (alignment == TEXT_ALIGNMENT::RIGHT) {
@@ -171,13 +173,18 @@ void DisplayManager_::printText(
         matrix->print(text);
     }
 
-    matrix->show();
+    if (updateMatrix) {
+        matrix->show();
+    }
 }
 
 void DisplayManager_::drawBitmap(
-    int16_t x, int16_t y, const uint8_t bitmap[], int16_t w, int16_t h, uint16_t color) {
+    int16_t x, int16_t y, const uint8_t bitmap[], int16_t w, int16_t h, uint16_t color, bool updateMatrix) {
     matrix->setCursor(x, y);
     matrix->drawBitmap(x, y, bitmap, w, h, color);
+    if (updateMatrix) {
+        matrix->show();
+    }
 }
 
 void DisplayManager_::scrollColorfulText(String message) {
@@ -320,7 +327,10 @@ void DisplayManager_::selectButtonLong() {}
 
 void DisplayManager_::update() { matrix->show(); }
 
-void DisplayManager_::clearMatrixPart(uint8_t x, uint8_t y, uint8_t width, uint8_t height) {
+void DisplayManager_::clearMatrixPart(
+    uint8_t x, uint8_t y, uint8_t width, uint8_t height, bool updateMatrix) {
     matrix->fillRect(x, y, width, height, 0);
-    matrix->show();
+    if (updateMatrix) {
+        matrix->show();
+    }
 }

--- a/src/DisplayManager.h
+++ b/src/DisplayManager.h
@@ -20,10 +20,14 @@ public:
     void tick();
 
     void HSVtext(int16_t x, int16_t y, const char* text, bool clear, byte textCase);
-    void printText(int16_t x, int16_t y, const char* text, TEXT_ALIGNMENT alignment, byte textCase);
+    void printText(
+        int16_t x, int16_t y, const char* text, TEXT_ALIGNMENT alignment, byte textCase,
+        bool updateMatrix = true);
     void setTextColor(uint16_t color);
-    void clearMatrix();
-    void drawBitmap(int16_t x, int16_t y, const uint8_t bitmap[], int16_t w, int16_t h, uint16_t color);
+    void clearMatrix(bool updateMatrix = true);
+    void drawBitmap(
+        int16_t x, int16_t y, const uint8_t bitmap[], int16_t w, int16_t h, uint16_t color,
+        bool updateMatrix = true);
     void showFatalError(String errorMessage);
     void scrollColorfulText(String message);
     void drawPixel(uint8_t x, uint8_t y, uint16_t color, bool updateMatrix = false);
@@ -36,7 +40,8 @@ public:
     void setPower(bool power);
     void setBrightness(int bri);
     void update();
-    void clearMatrixPart(uint8_t x, uint8_t y, uint8_t width, uint8_t height);
+    void clearMatrixPart(
+        uint8_t x, uint8_t y, uint8_t width, uint8_t height, bool updateMatrix = true);
     float getTextWidth(const char* text, byte textCase);
     void setFont(FONT_TYPE fontType);
 };

--- a/src/PeripheryManager.cpp
+++ b/src/PeripheryManager.cpp
@@ -27,6 +27,7 @@ MelodyPlayer player(BUZZER_PIN, 1, LOW);
 Button2 button_left(BUTTON_UP_PIN);
 Button2 button_right(BUTTON_DOWN_PIN);
 Button2 button_select(BUTTON_SELECT_PIN);
+const byte BUZZER_VOLUME = 64;
 
 #define USED_PHOTOCELL LightDependentResistor::GL5516
 #define PHOTOCELL_SERIES_RESISTOR 10000
@@ -120,6 +121,7 @@ void PeripheryManager_::setup() {
     DEBUG_PRINTLN(F("Setup periphery"));
     startTime = millis();
     pinMode(LDR_PIN, INPUT);
+    player.setVolume(BUZZER_VOLUME);
 
     button_left.setClickHandler(left_button_pressed);
     button_right.setClickHandler(right_button_pressed);

--- a/src/PeripheryManager.cpp
+++ b/src/PeripheryManager.cpp
@@ -48,6 +48,9 @@ float sampleSum = 0.0;
 float sampleAverage = 0.0;
 float brightnessPercent = 0.0;
 int lastBrightness = 0;
+unsigned long lastLowBatteryAlertMillis = 0;
+const unsigned long LOW_BATTERY_ALERT_INTERVAL_MS = 2UL * 60UL * 1000UL;
+const char* LOW_BATTERY_BEEP = "bat:d=32,o=6,b=220:c";
 
 // The getter for the instantiated singleton instance
 PeripheryManager_& PeripheryManager_::getInstance() {
@@ -154,6 +157,15 @@ void PeripheryManager_::tick() {
             sht31.readBoth(&CURRENT_TEMP, &CURRENT_HUM);
             CURRENT_TEMP += TEMP_OFFSET;
             CURRENT_HUM += HUM_OFFSET;
+        }
+        if (BATTERY_PERCENT <= 5) {
+            if (lastLowBatteryAlertMillis == 0 ||
+                currentMillis_BatTempHum - lastLowBatteryAlertMillis >= LOW_BATTERY_ALERT_INTERVAL_MS) {
+                PeripheryManager.playRTTTLString(LOW_BATTERY_BEEP);
+                lastLowBatteryAlertMillis = currentMillis_BatTempHum;
+            }
+        } else {
+            lastLowBatteryAlertMillis = 0;
         }
     }
 


### PR DESCRIPTION
See commit. Moves upload_port/upload_speed to an untracked platformio.local.ini via extra_configs; scripts read it first and fall back to platformio.ini; docs updated. Enables building/flashing on any machine without editing tracked files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)