### PR TITLE
Make the alarm repeat interval configurable

### DIFF
--- a/data/config_initial.json
+++ b/data/config_initial.json
@@ -44,6 +44,7 @@
     "alarm_low_melody": "",
     "alarm_urgent_low_melody": "",
     "alarm_intensive_mode": false,
+    "alarm_repeat_interval_seconds": 300,
     "librelinkup_email": "",
     "librelinkup_password": "",
     "librelinkup_region": "EU",

--- a/data/index.html
+++ b/data/index.html
@@ -657,7 +657,19 @@
                             </div>
                         </div>
                         <div class="row mt-3">
-                            <div class="col-12">
+                            <div class="col-sm-4">
+                                <label for="alarm_repeat_interval_seconds" class="form-label">Repeat every</label>
+                                <select class="form-select" id="alarm_repeat_interval_seconds" required>
+                                    <option value="60">1 minute</option>
+                                    <option value="120">2 minutes</option>
+                                    <option value="300">5 minutes</option>
+                                </select>
+                                <div class="form-text">
+                                    How long the alarm waits before sounding again while the reading stays
+                                    out of range, when nobody has snoozed it. Intensive mode ignores this.
+                                </div>
+                            </div>
+                            <div class="col-sm-8 align-content-center">
                                 <div class="form-check">
                                     <input class="form-check-input" type="checkbox" id="alarm_intensive_mode">
                                     <label class="form-check-label" for="alarm_intensive_mode">
@@ -675,7 +687,8 @@
                                         When an alarm condition is met (BG is low or high), the alarm will sound if
                                         enabled. The volume is moderate, so we recommend testing it with the "Try"
                                         buttons before enabling. The alarm will beep 2 times (high), 3 times (low),
-                                        or 4 times (urgent low), then pause for 5 minutes before sounding again. If
+                                        or 4 times (urgent low), then pause for the repeat interval you choose
+                                        below before sounding again. If
                                         "intense mode" is selected, the alarm will continue beeping every few
                                         seconds without pause. This cycle continues until blood glucose levels
                                         return to normal or until you press the "Select" (center) button to snooze.

--- a/data/index.html
+++ b/data/index.html
@@ -665,8 +665,8 @@
                                     <option value="300">5 minutes</option>
                                 </select>
                                 <div class="form-text">
-                                    How long the alarm waits before sounding again while the reading stays
-                                    out of range, when nobody has snoozed it. Intensive mode ignores this.
+                                    Time between alarm repeats when not snoozed. Intensive mode overrides
+                                    this setting.
                                 </div>
                             </div>
                             <div class="col-sm-8 align-content-center">
@@ -687,9 +687,9 @@
                                         When an alarm condition is met (BG is low or high), the alarm will sound if
                                         enabled. The volume is moderate, so we recommend testing it with the "Try"
                                         buttons before enabling. The alarm will beep 2 times (high), 3 times (low),
-                                        or 4 times (urgent low), then pause for the repeat interval you choose
-                                        below before sounding again. If
-                                        "intense mode" is selected, the alarm will continue beeping every few
+                                        or 4 times (urgent low), then pause for the selected repeat interval
+                                        before sounding again. If "Intensive mode" is selected, the alarm will
+                                        continue beeping every few
                                         seconds without pause. This cycle continues until blood glucose levels
                                         return to normal or until you press the "Select" (center) button to snooze.
                                         When snoozed, the clock displays "SNOOZED" for your selected snooze

--- a/data/script.js
+++ b/data/script.js
@@ -943,6 +943,7 @@
         setAlarmDataToJson(json, 'low');
         setAlarmDataToJson(json, 'urgent_low');
         json['alarm_intensive_mode'] = $('#alarm_intensive_mode').is(':checked');
+        json['alarm_repeat_interval_seconds'] = parseInt($('#alarm_repeat_interval_seconds').val());
 
         // Additional WiFi
         json['additional_wifi_enable'] = $('#additional_wifi_enable').is(':checked');
@@ -1294,6 +1295,7 @@
         loadAlarmDataFromJson(json, 'low');
         loadAlarmDataFromJson(json, 'urgent_low');
         $('#alarm_intensive_mode').prop('checked', json['alarm_intensive_mode']);
+        $('#alarm_repeat_interval_seconds').val(json['alarm_repeat_interval_seconds'] || 300);
 
         // Additional WiFi
         $('#additional_wifi_enable').prop('checked', json['additional_wifi_enable']);

--- a/data/script.js
+++ b/data/script.js
@@ -65,6 +65,7 @@
         $('#custom_hostname_enable').on('change', toggleCustomHostnameSettings);
         $('#custom_nodatatimer_enable').on('change', toggleCustomNoDataSettings);
         $('#web_auth_enable').on('change', toggleWebAuthSettings);
+        $('#alarm_intensive_mode').on('change', toggleAlarmRepeatSettings);
         $('#face_cycle_enabled').on('change', toggleFaceCycleSettings);
         $('.face-cycle-face').on('change', validateFaceCycleSelection);
         $('#open_wifi_network').on('change', toggleWifiPasswordField);
@@ -102,6 +103,11 @@
 
             };
         });
+    }
+
+    function toggleAlarmRepeatSettings() {
+        const intensiveMode = $('#alarm_intensive_mode').is(':checked');
+        $('#alarm_repeat_interval_seconds').prop('disabled', intensiveMode);
     }
 
     function toggleAdditionalWifiSettings() {
@@ -1295,7 +1301,11 @@
         loadAlarmDataFromJson(json, 'low');
         loadAlarmDataFromJson(json, 'urgent_low');
         $('#alarm_intensive_mode').prop('checked', json['alarm_intensive_mode']);
-        $('#alarm_repeat_interval_seconds').val(json['alarm_repeat_interval_seconds'] || 300);
+        const repeatInterval = json['alarm_repeat_interval_seconds'];
+        $('#alarm_repeat_interval_seconds').val(
+            [60, 120, 300].includes(repeatInterval) ? repeatInterval : 300
+        );
+        toggleAlarmRepeatSettings();
 
         // Additional WiFi
         $('#additional_wifi_enable').prop('checked', json['additional_wifi_enable']);

--- a/src/BGAlarmManager.cpp
+++ b/src/BGAlarmManager.cpp
@@ -6,7 +6,6 @@
 #include "ServerManager.h"
 #include "globals.h"
 
-#define ALARM_REPEAT_INTERVAL_SECONDS 300
 #define ALARM_REPEAT_INTERVAL_INTENSIVE_SECONDS 2
 
 static String pickAlarmMelody(const String& customMelody, const String& fallbackMelody) {
@@ -74,7 +73,7 @@ void BGAlarmManager_::setup() {
     if (SettingsManager.settings.alarm_intensive_mode) {
         alarmIntervalSeconds = ALARM_REPEAT_INTERVAL_INTENSIVE_SECONDS;  // repeat every 2 seconds
     } else {
-        alarmIntervalSeconds = ALARM_REPEAT_INTERVAL_SECONDS;
+        alarmIntervalSeconds = SettingsManager.settings.alarm_repeat_interval_seconds;
     }
 }
 

--- a/src/ServerManager.cpp
+++ b/src/ServerManager.cpp
@@ -436,9 +436,7 @@ void ServerManager_::setupWebServer(IPAddress ip) {
                 }
             }
 
-            // An unsupported repeat interval is corrected on the next load, so the file would be
-            // accepted and then quietly mean something else. Refuse it here instead, and ask
-            // SettingsManager which values it accepts rather than restating the list.
+            // Refuse a value the loader would silently correct; the accepted set lives in SettingsManager.
             if (!data["alarm_repeat_interval_seconds"].isNull()) {
                 if (!data["alarm_repeat_interval_seconds"].is<int>() ||
                     !SettingsManager_::isValidAlarmRepeatInterval(

--- a/src/ServerManager.cpp
+++ b/src/ServerManager.cpp
@@ -373,7 +373,7 @@ void ServerManager_::setupWebServer(IPAddress ip) {
                 return;
             }
             auto&& data = json.as<JsonObject>();
-            auto sendFaceCycleValidationError = [request](const char* error) {
+            auto sendSaveValidationError = [request](const char* error) {
                 String response = "{\"status\": \"error\", \"error\": \"";
                 response += error;
                 response += "\"}";
@@ -381,7 +381,7 @@ void ServerManager_::setupWebServer(IPAddress ip) {
             };
 
             if (!data["face_cycle_enabled"].isNull() && !data["face_cycle_enabled"].is<bool>()) {
-                sendFaceCycleValidationError("face_cycle_enabled must be a boolean");
+                sendSaveValidationError("face_cycle_enabled must be a boolean");
                 return;
             }
 
@@ -390,20 +390,20 @@ void ServerManager_::setupWebServer(IPAddress ip) {
             int uniqueFaceCount = 0;
             if (faceCycleEnabled || hasFaceCycleFaces) {
                 if (!data["face_cycle_faces"].is<JsonArray>()) {
-                    sendFaceCycleValidationError("face_cycle_faces must be an array");
+                    sendSaveValidationError("face_cycle_faces must be an array");
                     return;
                 }
 
                 bool selectedFaces[6] = {};
                 for (JsonVariant face : data["face_cycle_faces"].as<JsonArray>()) {
                     if (!face.is<int>()) {
-                        sendFaceCycleValidationError("Face selections must use IDs from 0 to 5");
+                        sendSaveValidationError("Face selections must use IDs from 0 to 5");
                         return;
                     }
 
                     int faceId = face.as<int>();
                     if (faceId < 0 || faceId >= 6) {
-                        sendFaceCycleValidationError("Face selections must use IDs from 0 to 5");
+                        sendSaveValidationError("Face selections must use IDs from 0 to 5");
                         return;
                     }
 
@@ -415,14 +415,14 @@ void ServerManager_::setupWebServer(IPAddress ip) {
             }
 
             if (faceCycleEnabled && uniqueFaceCount < 2) {
-                sendFaceCycleValidationError("Select at least two different clock faces");
+                sendSaveValidationError("Select at least two different clock faces");
                 return;
             }
 
             bool hasFaceCycleInterval = !data["face_cycle_interval_seconds"].isNull();
             if (faceCycleEnabled || hasFaceCycleInterval) {
                 if (!data["face_cycle_interval_seconds"].is<int>()) {
-                    sendFaceCycleValidationError(
+                    sendSaveValidationError(
                         "Face cycle period must be 10, 30, 60, 120, 180, or 300 seconds");
                     return;
                 }
@@ -430,8 +430,21 @@ void ServerManager_::setupWebServer(IPAddress ip) {
                 int intervalSeconds = data["face_cycle_interval_seconds"].as<int>();
                 if (intervalSeconds != 10 && intervalSeconds != 30 && intervalSeconds != 60 &&
                     intervalSeconds != 120 && intervalSeconds != 180 && intervalSeconds != 300) {
-                    sendFaceCycleValidationError(
+                    sendSaveValidationError(
                         "Face cycle period must be 10, 30, 60, 120, 180, or 300 seconds");
+                    return;
+                }
+            }
+
+            // An unsupported repeat interval is corrected on the next load, so the file would be
+            // accepted and then quietly mean something else. Refuse it here instead, and ask
+            // SettingsManager which values it accepts rather than restating the list.
+            if (!data["alarm_repeat_interval_seconds"].isNull()) {
+                if (!data["alarm_repeat_interval_seconds"].is<int>() ||
+                    !SettingsManager_::isValidAlarmRepeatInterval(
+                        data["alarm_repeat_interval_seconds"].as<int>())) {
+                    sendSaveValidationError(
+                        "Alarm repeat interval must be 60, 120, or 300 seconds");
                     return;
                 }
             }

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -63,6 +63,7 @@ public:
     int bg_data_too_old_threshold_minutes = 20;
     DISPLAY_COLOR data_old_color = DISPLAY_COLOR::GRAY;
     bool alarm_intensive_mode;
+    int alarm_repeat_interval_seconds = 300;
     bool web_auth_enable;
     String web_auth_password;
 };

--- a/src/SettingsManager.cpp
+++ b/src/SettingsManager.cpp
@@ -7,10 +7,6 @@
 #include "globals.h"
 
 namespace {
-bool isValidAlarmRepeatInterval(int intervalSeconds) {
-    return intervalSeconds == 60 || intervalSeconds == 120 || intervalSeconds == 300;
-}
-
 bool isValidFaceCycleInterval(int intervalSeconds) {
     return intervalSeconds == 10 || intervalSeconds == 30 || intervalSeconds == 60 ||
            intervalSeconds == 120 || intervalSeconds == 180 || intervalSeconds == 300;
@@ -84,6 +80,10 @@ JsonDocument* SettingsManager_::readConfigJsonFile() {
         factoryReset();
         return NULL;
     }
+}
+
+bool SettingsManager_::isValidAlarmRepeatInterval(int intervalSeconds) {
+    return intervalSeconds == 60 || intervalSeconds == 120 || intervalSeconds == 300;
 }
 
 bool SettingsManager_::loadSettingsFromFile() {

--- a/src/SettingsManager.cpp
+++ b/src/SettingsManager.cpp
@@ -7,6 +7,10 @@
 #include "globals.h"
 
 namespace {
+bool isValidAlarmRepeatInterval(int intervalSeconds) {
+    return intervalSeconds == 60 || intervalSeconds == 120 || intervalSeconds == 300;
+}
+
 bool isValidFaceCycleInterval(int intervalSeconds) {
     return intervalSeconds == 10 || intervalSeconds == 30 || intervalSeconds == 60 ||
            intervalSeconds == 120 || intervalSeconds == 180 || intervalSeconds == 300;
@@ -209,6 +213,12 @@ bool SettingsManager_::loadSettingsFromFile() {
     settings.alarm_urgent_low_melody = (*doc)["alarm_urgent_low_melody"].as<String>();
     settings.alarm_intensive_mode = (*doc)["alarm_intensive_mode"].as<bool>();
 
+    settings.alarm_repeat_interval_seconds = (*doc)["alarm_repeat_interval_seconds"] | 300;
+    if (!isValidAlarmRepeatInterval(settings.alarm_repeat_interval_seconds)) {
+        DEBUG_PRINTLN("Invalid alarm repeat interval in config, defaulting to 300 seconds");
+        settings.alarm_repeat_interval_seconds = 300;
+    }
+
     // Additional WiFi
     settings.additional_wifi_enable = (*doc)["additional_wifi_enable"].as<bool>();
     settings.additional_wifi_type = (*doc)["additional_wifi_type"].as<String>();
@@ -349,6 +359,7 @@ bool SettingsManager_::saveSettingsToFile() {
     (*doc)["alarm_low_melody"] = settings.alarm_low_melody;
     (*doc)["alarm_urgent_low_melody"] = settings.alarm_urgent_low_melody;
     (*doc)["alarm_intensive_mode"] = settings.alarm_intensive_mode;
+    (*doc)["alarm_repeat_interval_seconds"] = settings.alarm_repeat_interval_seconds;
 
     // Additional WiFi
     (*doc)["additional_wifi_enable"] = settings.additional_wifi_enable;

--- a/src/SettingsManager.h
+++ b/src/SettingsManager.h
@@ -19,8 +19,7 @@ public:
     bool saveSettingsToFile();
     bool trySaveJsonAsSettings(JsonDocument doc);
     void factoryReset();
-    // The alarm repeat intervals the WebUI offers. Public so the save endpoint can hold a posted
-    // value to the same set the loader does, rather than restating it.
+    // The repeat intervals the WebUI offers; shared with the save endpoint.
     static bool isValidAlarmRepeatInterval(int intervalSeconds);
 
     Settings settings;

--- a/src/SettingsManager.h
+++ b/src/SettingsManager.h
@@ -19,6 +19,9 @@ public:
     bool saveSettingsToFile();
     bool trySaveJsonAsSettings(JsonDocument doc);
     void factoryReset();
+    // The alarm repeat intervals the WebUI offers. Public so the save endpoint can hold a posted
+    // value to the same set the loader does, rather than restating it.
+    static bool isValidAlarmRepeatInterval(int intervalSeconds);
 
     Settings settings;
 };


### PR DESCRIPTION
### What changed

The pause between alarm repeats was fixed at 5 minutes (`ALARM_REPEAT_INTERVAL_SECONDS`). It is now chosen in the web UI — 1, 2 or 5 minutes — and **defaults to the 5 minutes it has always been**, so an existing clock behaves identically until somebody changes it. The choice is deliberately only in the more insistent direction; see the discussion below.

Intensive mode is untouched and still overrides the setting with its 2 second repeat.

### Why

Five minutes is a long time to wait when a reading is heading the wrong way, and too often when it is sitting just over the line and already being dealt with. Which of those is true depends on the person and the clock, so it is not something a single constant can get right.

### Notes for review

- Validated in two places: on load, defaulting to 300 if the stored value is not one the dropdown offers, in the style of the existing `isValidFaceCycleInterval`; and at `/api/save` before anything is written, so a posted value that is not supported is refused rather than accepted and quietly corrected on the next boot. `face_cycle_interval_seconds`, the other enumerated setting in that handler, was already checked there.
- `isValidAlarmRepeatInterval` moved from an anonymous namespace to a public static so the endpoint asks `SettingsManager` which values it accepts instead of restating the list. The error helper in `ServerManager` is now `sendSaveValidationError`, since it no longer validates only face cycling.
- The "How alarms work" panel said "pause for 5 minutes"; it now points at the setting.
- Independent of #183 — the two touch the same alarm card but at different anchors, and merge cleanly in either order.

### How it was tested

Builds clean on `ulanzi_debug`. The web UI was driven against a local stand-in for the device's web server: a config without the key loads the 300 default, and a changed selection reaches the saved configuration as `alarm_repeat_interval_seconds`.

**Not yet run on real hardware.** I have live units and did not want to reflash one before you had seen the approach. Say the word and I will do a hardware pass and report back before you merge.